### PR TITLE
Use theme defined in the tenant

### DIFF
--- a/eox_theming/configuration/__init__.py
+++ b/eox_theming/configuration/__init__.py
@@ -34,3 +34,21 @@ class ThemingConfiguration(object):
             value = kwargs.pop('default', None)
 
         return value
+
+    @classmethod
+    def get_theme_name(cls):
+        """
+        Get the current theme name
+
+        Returns:
+            (str): Theme name associated to the request.
+        """
+        theme_name = cls.options('theme', 'name', default=None)
+
+        if not theme_name:
+            theme_name = cls.options('template_dir', default=settings.EOX_THEMING_DEFAULT_THEME_NAME)
+
+        if theme_name:
+            theme_name = theme_name.split('/')[-1]
+
+        return theme_name

--- a/eox_theming/settings/production.py
+++ b/eox_theming/settings/production.py
@@ -10,4 +10,7 @@ def plugin_settings(settings):  # pylint: disable=unused-argument
     Set of plugin settings used by the Open Edx platform.
     More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
-    pass
+    settings.EOX_THEMING_DEFAULT_THEME_NAME = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_THEMING_DEFAULT_THEME_NAME',
+        settings.EOX_THEMING_DEFAULT_THEME_NAME
+    )

--- a/eox_theming/settings/test.py
+++ b/eox_theming/settings/test.py
@@ -35,6 +35,8 @@ TEMPLATES = [
     },
 ]
 
+EOX_THEMING_DEFAULT_THEME_NAME = 'default-theme'
+
 
 def plugin_settings(settings):  # pylint: disable=function-redefined, unused-argument
     """

--- a/eox_theming/tests/test_configuration.py
+++ b/eox_theming/tests/test_configuration.py
@@ -29,3 +29,18 @@ class TestThemingConfiguration(TestCase):
         """ Calling options with error data must return the Default """
         result = ThemingConfiguration.options('section', 'item', default='Unique_string')
         self.assertEqual('Unique_string', result)
+
+    def test_get_theme_name(self):
+        """
+        Test get_theme_name function.
+        """
+        theme = ThemingConfiguration.get_theme_name()
+        self.assertEqual(theme, 'default-theme')  # pylint: disable=no-member
+
+    @override_settings(EOX_THEMING_DEFAULT_THEME_NAME='default-theme/inherits/other-theme')
+    def test_get_theme_name_tenant(self):
+        """
+        Test get_theme_name for microsite v0.
+        """
+        theme = ThemingConfiguration.get_theme_name()
+        self.assertEqual(theme, 'other-theme')  # pylint: disable=no-member

--- a/eox_theming/theming/middleware.py
+++ b/eox_theming/theming/middleware.py
@@ -1,8 +1,8 @@
 """
 Plugin middlewares
 """
-from django.conf import settings
 from eox_theming.edxapp_wrapper.models import get_openedx_site_theme_model
+from eox_theming.configuration import ThemingConfiguration
 
 SITE_THEME = get_openedx_site_theme_model()
 
@@ -20,8 +20,12 @@ class EoxThemeMiddleware(object):
         Set the request's 'site_theme'
         """
         # TODO: resolve. If the site does not exist, should we create it? or use a placeholder site_id
-        current_theme, _ = SITE_THEME.objects.get_or_create(
-            site_id=1,
-            theme_dir_name=settings.EOX_THEMING_DEFAULT_THEME_NAME,
-        )
-        request.site_theme = current_theme
+
+        theme_name = ThemingConfiguration.get_theme_name()
+
+        if theme_name:
+            current_theme, _ = SITE_THEME.objects.get_or_create(
+                site_id=1,
+                theme_dir_name=theme_name,
+            )
+            request.site_theme = current_theme


### PR DESCRIPTION
This PR changes the eox theming middleware to set the theme defined in the tenant configuration if it is defined.

The value of settings.EOX_THEMING_DEFAULT_THEME_NAME is taken from the ENV_FILE if defined (I am assuming that eox-tenant is not installed)