### PR TITLE
Inherit mako templates from default site theme

### DIFF
--- a/eox_theming/apps.py
+++ b/eox_theming/apps.py
@@ -5,6 +5,7 @@ App configuration for eox_theming.
 from __future__ import unicode_literals
 
 from django.apps import AppConfig
+from django.conf import settings
 
 
 class EoxThemingConfig(AppConfig):
@@ -43,3 +44,19 @@ class EoxThemingConfig(AppConfig):
             },
         }
     }
+
+    def ready(self):
+        """
+        Method to perform actions after apps registry is ended
+        Setup mako lookup directories.
+        See: common.djangoapps.edxmako.apps.py
+        """
+        from eox_theming.theming.paths import add_lookup, clear_lookups
+        for backend in settings.TEMPLATES:
+            if 'edxmako' not in backend['BACKEND']:
+                continue
+            namespace = backend['OPTIONS'].get('namespace', 'main')
+            directories = backend['DIRS']
+            clear_lookups(namespace)
+            for directory in directories:
+                add_lookup(namespace, directory)

--- a/eox_theming/edxapp_wrapper/backends/i_mako.py
+++ b/eox_theming/edxapp_wrapper/backends/i_mako.py
@@ -1,0 +1,25 @@
+""" Backend abstraction for edxmako. """
+
+from edxmako import LOOKUP, clear_lookups  # pylint: disable=import-error
+
+from edxmako.paths import DynamicTemplateLookup, TopLevelTemplateURI  # pylint: disable=import-error
+
+
+def get_dynamictemplate_lookup():
+    """ Get DynamicTemplateLookup. """
+    return DynamicTemplateLookup
+
+
+def get_top_level_template_uri():
+    """ Get TopLevelTemplateURI"""
+    return TopLevelTemplateURI
+
+
+def get_lookup():
+    """ Get edxmako LOOKUP dict"""
+    return LOOKUP
+
+
+def get_clear_lookups():
+    """ Get clear_lookups function """
+    return clear_lookups

--- a/eox_theming/edxapp_wrapper/backends/i_mako_tests.py
+++ b/eox_theming/edxapp_wrapper/backends/i_mako_tests.py
@@ -1,0 +1,24 @@
+""" Backend abstraction for edxmako used in tests. """
+
+
+def get_dynamictemplate_lookup():
+    """ Abstraction for tests. """
+    return object
+
+
+def get_top_level_template_uri():
+    """ Abstraction for tests. """
+    return object
+
+
+def get_lookup():
+    """ Abstraction for tests. """
+    return {}
+
+
+def get_clear_lookups():
+    """ Abstraction for tests. """
+    def mock_function():
+        """function for the tests"""
+        return
+    return mock_function

--- a/eox_theming/edxapp_wrapper/mako.py
+++ b/eox_theming/edxapp_wrapper/mako.py
@@ -1,0 +1,31 @@
+""" Backend abstraction for edxmako. """
+from importlib import import_module
+from django.conf import settings
+
+
+def get_dynamictemplate_lookup(*args, **kwargs):
+    """ Get DynamicTemplateLookup class """
+    backend_function = settings.EOX_THEMING_EDXMAKO_BACKEND
+    backend = import_module(backend_function)
+    return backend.get_dynamictemplate_lookup(*args, **kwargs)
+
+
+def get_top_level_template_uri(*args, **kwargs):
+    """ Get TopLevelTemplateUri """
+    backend_function = settings.EOX_THEMING_EDXMAKO_BACKEND
+    backend = import_module(backend_function)
+    return backend.get_top_level_template_uri(*args, **kwargs)
+
+
+def get_lookup(*args, **kwargs):
+    """ Get lookup from platform code """
+    backend_function = settings.EOX_THEMING_EDXMAKO_BACKEND
+    backend = import_module(backend_function)
+    return backend.get_lookup(*args, **kwargs)
+
+
+def get_clear_lookups(*args, **kwargs):
+    """ Get clear lookups function """
+    backend_function = settings.EOX_THEMING_EDXMAKO_BACKEND
+    backend = import_module(backend_function)
+    return backend.get_clear_lookups(*args, **kwargs)

--- a/eox_theming/settings/common.py
+++ b/eox_theming/settings/common.py
@@ -91,3 +91,4 @@ def plugin_settings(settings):
     settings.EOX_THEMING_SITE_THEME_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_models'
     settings.EOX_THEMING_CONFIGURATION_HELPER_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_configuration_helpers'
     settings.EOX_THEMING_THEMING_HELPER_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_theming_helpers'
+    settings.EOX_THEMING_EDXMAKO_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_mako'

--- a/eox_theming/settings/test.py
+++ b/eox_theming/settings/test.py
@@ -39,6 +39,7 @@ EOX_THEMING_DEFAULT_THEME_NAME = 'default-theme'
 
 EOX_THEMING_CONFIGURATION_HELPER_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_configuration_helpers_tests'
 EOX_THEMING_THEMING_HELPER_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_theming_helpers_tests'
+EOX_THEMING_EDXMAKO_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_mako_tests'
 
 
 def plugin_settings(settings):  # pylint: disable=function-redefined, unused-argument

--- a/eox_theming/tests/theming/test_paths.py
+++ b/eox_theming/tests/theming/test_paths.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
+"""
+Tests for eox theming paths
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.test import TestCase
+
+from path import Path
+
+from mock import patch, mock
+
+from eox_theming.theming.paths import strip_site_theme_templates_path, get_template_path_with_theme
+
+
+class ThemingPathsTest(TestCase):
+    """ Tests for the eox_theming paths module """
+
+    @patch('eox_theming.configuration.ThemingConfiguration.theming_helpers')
+    @patch('eox_theming.configuration.ThemingConfiguration.get_parent_or_default_theme')
+    def test_strip_site_theme_from_uri(self, parent_mock, helper_mock):
+        """
+        Test site theme templates path is stripped from the given template path.
+        """
+        theme = mock.Mock()
+        theme.theme_dir_name = 'bragi'
+        helper_mock.get_current_theme.return_value = theme
+        helper_mock.get_project_root_name.return_value = 'lms'
+
+        default_theme = mock.Mock()
+        default_theme.theme_dir_name = 'default-theme'
+        default_theme.name = 'default_theme'
+        default_theme.path = Path('/themes/default_theme/lms')
+        default_theme.template_path = Path('default-theme/lms/templates')
+
+        parent_mock.return_value = default_theme
+        template_path = strip_site_theme_templates_path('bragi/lms/templates/header.html')
+        self.assertEqual(template_path, 'header.html')
+
+    @patch('eox_theming.configuration.ThemingConfiguration.theming_helpers')
+    @patch('eox_theming.configuration.ThemingConfiguration.get_parent_or_default_theme')
+    def test_strip_site_default_theme_from_uri(self, parent_mock, helper_mock):
+        """
+        Test default site theme templates path is stripped from the given template path.
+        """
+        theme = mock.Mock()
+        theme.theme_dir_name = 'bragi'
+        theme.name = 'bragi'
+        helper_mock.get_current_theme.return_value = theme
+        helper_mock.get_project_root_name.return_value = 'lms'
+
+        default_theme = mock.Mock()
+        default_theme.theme_dir_name = 'default-theme'
+        default_theme.name = 'default_theme'
+        default_theme.path = Path('/themes/default_theme/lms')
+        default_theme.template_path = Path('default-theme/lms/templates')
+
+        parent_mock.return_value = default_theme
+        template_path = strip_site_theme_templates_path('default-theme/lms/templates/header.html')
+        self.assertEqual(template_path, 'header.html')
+
+        template_path = strip_site_theme_templates_path('/theme-name/lms/templates/header.html')
+        self.assertNotEqual(template_path, 'header.html')
+
+    @patch('os.path.exists')
+    @patch('eox_theming.configuration.ThemingConfiguration.theming_helpers')
+    @patch('eox_theming.configuration.Theme')
+    def test_get_template_path_with_theme(self, theme_mock, helper_mock, os_mock):
+        """
+        Tests template paths are returned from enabled theme.
+        """
+        os_mock.return_value = True
+
+        theme = mock.Mock()
+        theme.theme_dir_name = 'bragi'
+        theme.path = Path('/themes/bragi/lms')
+        theme.template_path = Path('bragi/lms/templates')
+        helper_mock.get_current_theme.return_value = theme
+        helper_mock.get_project_root_name.return_value = 'lms'
+
+        template_path = get_template_path_with_theme('header.html')
+
+        theme_mock.assert_called_once()
+        self.assertEqual(template_path, 'bragi/lms/templates/header.html')
+
+    @patch('os.path.exists')
+    @patch('eox_theming.configuration.ThemingConfiguration.theming_helpers')
+    @patch('eox_theming.configuration.ThemingConfiguration.get_parent_or_default_theme')
+    def test_get_template_with_parent_theme(self, parent_mock, helper_mock, os_mock):
+        """
+        Tests parent theme template paths are returned if template is not found in the theme.
+        """
+        os_mock.side_effect = [False, True]
+        theme = mock.Mock()
+        theme.theme_dir_name = 'bragi'
+        theme.name = 'bragi'
+        theme.path = Path('/themes/bragi/lms')
+        theme.template_path = Path('bragi/lms/templates')
+
+        default_theme = mock.Mock()
+        default_theme.theme_dir_name = 'default-theme'
+        default_theme.name = 'default_theme'
+        default_theme.path = Path('/themes/default_theme/lms')
+        default_theme.template_path = Path('default-theme/lms/templates')
+
+        parent_mock.return_value = default_theme
+
+        helper_mock.get_current_theme.return_value = theme
+        helper_mock.get_project_root_name.return_value = 'lms'
+
+        template_path = get_template_path_with_theme('header.html')
+        self.assertEqual(template_path, 'default-theme/lms/templates/header.html')
+
+    @patch('os.path.exists')
+    @patch('eox_theming.configuration.ThemingConfiguration.theming_helpers')
+    @patch('eox_theming.configuration.ThemingConfiguration.get_parent_or_default_theme')
+    def test_get_template_not_found_in_themes(self, parent_mock, helper_mock, os_mock):
+        """
+        Tests default template paths are returned if template is not found in the theme.
+        """
+        os_mock.side_effect = [False, False]
+        theme = mock.Mock()
+        theme.theme_dir_name = 'bragi'
+        theme.name = 'bragi'
+        theme.path = Path('/themes/bragi/lms')
+        theme.template_path = Path('bragi/lms/templates')
+
+        default_theme = mock.Mock()
+        default_theme.theme_dir_name = 'default-theme'
+        default_theme.name = 'default_theme'
+        default_theme.path = Path('/themes/default_theme/lms')
+        default_theme.template_path = Path('default-theme/lms/templates')
+
+        parent_mock.return_value = default_theme
+        helper_mock.get_current_theme.return_value = theme
+        helper_mock.get_project_root_name.return_value = 'lms'
+
+        template_path = get_template_path_with_theme('header.html')
+        self.assertEqual(template_path, 'header.html')

--- a/eox_theming/theming/paths.py
+++ b/eox_theming/theming/paths.py
@@ -1,0 +1,188 @@
+"""
+Set up lookup paths for mako templates.
+
+See: common.djangoapps.edxmako.paths
+"""
+
+import os
+import re
+
+import pkg_resources
+
+from django.conf import settings
+
+from mako.exceptions import TopLevelLookupException  # pylint: disable=import-error
+
+from eox_theming.configuration import ThemingConfiguration
+
+from eox_theming.edxapp_wrapper.mako import (
+    get_dynamictemplate_lookup,
+    get_top_level_template_uri,
+    get_lookup,
+    get_clear_lookups
+)
+
+
+DynamicTemplateLookup = get_dynamictemplate_lookup()
+TopLevelTemplateURI = get_top_level_template_uri()
+LOOKUP = get_lookup()
+clear_lookups = get_clear_lookups()
+
+
+class EoxDynamicTemplateLookup(DynamicTemplateLookup):
+    """
+    The eox theme EoxDynamicTemplateLookup is the intervention point to make sure
+    that we are loading the templates from the request theme and the default site theme.
+
+    See: common.djangoapps.edxmako.paths
+    """
+    def adjust_uri(self, uri, calling_uri):
+        """
+        This method was reimplemented to use eox-theming strip_site_theme_templates_path and
+        get_template_path_with_theme instead of the equivalent functions used in the platform.
+        """
+        # Make requested uri relative to the calling uri.
+        relative_uri = super(EoxDynamicTemplateLookup, self).adjust_uri(uri, calling_uri)
+        # Is the calling template (calling_uri) which is including or inheriting current template (uri)
+        # located inside a theme?
+        if calling_uri != strip_site_theme_templates_path(calling_uri):
+            # Is the calling template trying to include/inherit itself?
+            if calling_uri == get_template_path_with_theme(strip_site_theme_templates_path(relative_uri)):
+                return TopLevelTemplateURI(relative_uri)
+        return get_template_path_with_theme(strip_site_theme_templates_path(relative_uri))
+
+    def get_template(self, uri):
+        """
+        Overridden method for using get_template_path_with_theme from eox-theming instead of the function used in
+        the platform.
+        """
+
+        if isinstance(uri, TopLevelTemplateURI):
+            template = self._get_toplevel_template(uri)
+        else:
+            try:
+                # Try to find themed template, i.e. see if current theme overrides the template
+                template = super(EoxDynamicTemplateLookup, self).get_template(get_template_path_with_theme(uri))
+            except TopLevelLookupException:
+                template = self._get_toplevel_template(uri)
+
+        return template
+
+    def _get_toplevel_template(self, uri):
+        """
+        Lookup a default/toplevel template, ignoring current theme.
+        """
+        # Strip off the prefix path to request theme and parent theme and look in default template dirs.
+        return super(EoxDynamicTemplateLookup, self)._get_toplevel_template(strip_site_theme_templates_path(uri))
+
+
+def add_lookup(namespace, directory, package=None, prepend=False):
+    """
+    The difference with the edxmako implementation is that this uses the EoxDynamicTemplateLookup
+    instead of DynamicTemplateLookup.
+
+    See: common.djangoapps.edxmako.paths
+
+    """
+    templates = LOOKUP.get(namespace)
+    if not templates:
+        LOOKUP[namespace] = templates = EoxDynamicTemplateLookup(
+            module_directory=settings.MAKO_MODULE_DIR,
+            output_encoding='utf-8',
+            input_encoding='utf-8',
+            default_filters=['decode.utf8'],
+            encoding_errors='replace',
+        )
+    if package:
+        directory = pkg_resources.resource_filename(package, directory)
+    templates.add_directory(directory, prepend=prepend)
+
+
+def get_template_path_with_theme(relative_path):
+    """
+    The change with respect of the edx-platform version is that in this case, the templates are
+    not searched only on the current site theme. They are also searched in the parent(default) theme.
+
+    See: openedx.core.djangoapps.theming.helpers
+
+    Example:
+        >> get_template_path_with_theme('header.html')
+        '/red-theme/lms/templates/header.html'
+
+    Parameters:
+        relative_path (str): template's path relative to the templates directory e.g. 'footer.html'
+
+    Returns:
+        (str): template path in current site's theme
+    """
+    relative_path = os.path.normpath(relative_path)
+    template_name = re.sub(r'^/+', '', relative_path)
+
+    theme = ThemingConfiguration.theming_helpers.get_current_theme()
+    parent_theme = ThemingConfiguration.get_parent_or_default_theme()
+
+    if theme:
+        # strip `/` if present at the start of relative_path
+        template_path = theme.template_path / template_name
+        absolute_path = theme.path / "templates" / template_name
+        if absolute_path.exists():
+            return str(template_path)
+
+        if not parent_theme or theme.name == parent_theme.name:
+            return relative_path
+
+    # Try with the parent site theme
+    if not parent_theme:
+        return relative_path
+
+    template_path = parent_theme.template_path / template_name
+    absolute_path = parent_theme.path / "templates" / template_name
+
+    if absolute_path.exists():
+        return str(template_path)
+
+    return relative_path
+
+
+def strip_site_theme_templates_path(uri):
+    """
+    The change with respect of the edx-platform version is that in this case, are stripped the
+    theme and parent theme from the uri
+
+    See: openedx.core.djangoapps.theming.helpers
+
+    Example:
+        >> strip_site_theme_templates_path('/red-theme/lms/templates/header.html')
+        'header.html'
+
+    Arguments:
+        uri (str): template path from which to remove site theme path. e.g. '/red-theme/lms/templates/header.html'
+
+    Returns:
+        (str): template path with site theme path removed.
+    """
+    theme = ThemingConfiguration.theming_helpers.get_current_theme()
+    parent_theme = ThemingConfiguration.get_parent_or_default_theme()
+
+    if theme:
+        templates_path = "/".join([
+            theme.theme_dir_name,
+            ThemingConfiguration.theming_helpers.get_project_root_name(),
+            "templates"
+        ])
+
+        uri = re.sub(r'^/*' + templates_path + '/*', '', uri)
+
+    if not parent_theme:
+        return uri
+
+    # Do the same with the parent theme
+    templates_path = "/".join([
+        parent_theme.theme_dir_name,
+        ThemingConfiguration.theming_helpers.get_project_root_name(),
+        "templates"
+    ])
+
+    uri = re.sub(r'^/*' + templates_path + '/*', '', uri)
+
+    return uri

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -2,3 +2,5 @@ mock==2.0.0
 pylint==1.9.3
 pycodestyle==2.5.0
 coverage==4.5.1
+mako==1.0.2
+path.py==8.2.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 astroid==1.6.6            # via pylint
 backports.functools-lru-cache==1.5  # via astroid, isort, pylint
-configparser==3.8.1       # via pylint
+configparser==4.0.2       # via pylint
 coverage==4.5.1
 django==1.11.24
 enum34==1.1.6             # via astroid
@@ -14,9 +14,12 @@ funcsigs==1.0.2           # via mock
 futures==3.3.0 ; python_version < "3.0"
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.2  # via astroid
+mako==1.0.2
+markupsafe==1.1.1         # via mako
 mccabe==0.6.1             # via pylint
 mock==2.0.0
-pbr==5.4.2                # via mock
+path.py==8.2.1
+pbr==5.4.3                # via mock
 pycodestyle==2.5.0
 pylint==1.9.3
 pytz==2019.2              # via django


### PR DESCRIPTION
Adds the capability to inherit templates from parent theme.

How to test:

On devstack, install this version of eox-theming,

Add to the django settings:

```
THEME_OPTIONS = {
    "theme": {
        "name": "bragi",
        "parent": "gefion"
    }
}
```
Access to a site, i.e. site1.localhost:18000. Make sure that a mako template is being loaded from bragi theme. (for instance, the footer)

Remove that template from the bragi theme, and then make sure that it is being loaded that template from the gefion theme.

Remove that template from the gefion theme, and then make sure that it is being loaded that template from platform code.