### PR TITLE
Extend ThemeTemplateLoader

### DIFF
--- a/eox_theming/edxapp_wrapper/backends/i_loaders.py
+++ b/eox_theming/edxapp_wrapper/backends/i_loaders.py
@@ -1,9 +1,14 @@
 """
 Simple backend that returns the platform's ThemeTemplateLoader class
 """
-from openedx.core.djangoapps.theming.template_loaders import ThemeTemplateLoader  # pylint: disable=import-error
+from openedx.core.djangoapps.theming.template_loaders import ThemeTemplateLoader, ThemeFilesystemLoader  # pylint: disable=import-error
 
 
 def get_openedx_theme_loader():
     """Return the template loader class when called during runtime"""
     return ThemeTemplateLoader
+
+
+def get_theme_filesystem_loader():
+    """Return the filesystem loader class when called during runtime"""
+    return ThemeFilesystemLoader

--- a/eox_theming/edxapp_wrapper/backends/i_loaders_tests.py
+++ b/eox_theming/edxapp_wrapper/backends/i_loaders_tests.py
@@ -1,0 +1,13 @@
+"""
+Simple abstraction for tests
+"""
+
+
+def get_openedx_theme_loader():
+    """Abstraction for tests"""
+    return object
+
+
+def get_theme_filesystem_loader():
+    """Abstraction for tests"""
+    return object

--- a/eox_theming/edxapp_wrapper/backends/i_mako.py
+++ b/eox_theming/edxapp_wrapper/backends/i_mako.py
@@ -1,0 +1,8 @@
+""" Backend abstraction for edxmako. """
+
+from edxmako.makoloader import MakoLoader  # pylint: disable=import-error
+
+
+def get_mako_loader():
+    """ Get MakoLoader. """
+    return MakoLoader

--- a/eox_theming/edxapp_wrapper/backends/i_mako_tests.py
+++ b/eox_theming/edxapp_wrapper/backends/i_mako_tests.py
@@ -1,0 +1,6 @@
+""" Backend abstraction for edxmako used in tests. """
+
+
+def get_mako_loader():
+    """ Get MakoLoader. """
+    return object

--- a/eox_theming/edxapp_wrapper/loaders.py
+++ b/eox_theming/edxapp_wrapper/loaders.py
@@ -7,7 +7,11 @@ from django.conf import settings
 
 def get_openedx_theme_loader():
     """ Get the Open edX template loader class. """
-
     backend = import_module(settings.EOX_THEMING_BASE_LOADER_BACKEND)
-
     return backend.get_openedx_theme_loader()
+
+
+def get_theme_filesystem_loader():
+    """ Get the Open edX filesystem loader class. """
+    backend = import_module(settings.EOX_THEMING_BASE_LOADER_BACKEND)
+    return backend.get_theme_filesystem_loader()

--- a/eox_theming/edxapp_wrapper/mako.py
+++ b/eox_theming/edxapp_wrapper/mako.py
@@ -1,0 +1,10 @@
+""" Backend abstraction for edxmako. """
+from importlib import import_module
+from django.conf import settings
+
+
+def get_mako_loader():
+    """ Get mako loader """
+    backend_function = settings.EOX_THEMING_EDXMAKO_BACKEND
+    backend = import_module(backend_function)
+    return backend.get_mako_loader()

--- a/eox_theming/settings/common.py
+++ b/eox_theming/settings/common.py
@@ -94,3 +94,4 @@ def plugin_settings(settings):
     settings.EOX_THEMING_STORAGE_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_storage'
 
     settings.STATICFILES_STORAGE = 'eox_theming.theming.storage.EoxProductionStorage'
+    settings.EOX_THEMING_EDXMAKO_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_mako'

--- a/eox_theming/settings/test.py
+++ b/eox_theming/settings/test.py
@@ -39,6 +39,8 @@ EOX_THEMING_DEFAULT_THEME_NAME = 'default-theme'
 
 EOX_THEMING_CONFIGURATION_HELPER_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_configuration_helpers_tests'
 EOX_THEMING_THEMING_HELPER_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_theming_helpers_tests'
+EOX_THEMING_EDXMAKO_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_mako_tests'
+EOX_THEMING_BASE_LOADER_BACKEND = 'eox_theming.edxapp_wrapper.backends.i_loaders_tests'
 
 
 def plugin_settings(settings):  # pylint: disable=function-redefined, unused-argument

--- a/eox_theming/tests/theming/test_template_loaders.py
+++ b/eox_theming/tests/theming/test_template_loaders.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
+"""
+Tests for the template loaders
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.test import TestCase
+from mock import patch, mock
+from path import Path
+
+from eox_theming.theming.template_loaders import EoxThemeFilesystemLoader
+
+
+class TestsEoxFSLoader(TestCase):
+    """ Tests for the eox_theming filesystem loader """
+
+    @patch('eox_theming.configuration.ThemingConfiguration.theming_helpers')
+    @patch('eox_theming.configuration.ThemingConfiguration.get_parent_or_default_theme')
+    def test_returned_default_theme_template_sources(self, parent_mock, helper_mock):
+        """
+        Test if it is returned the template dirs of the default theme.
+        """
+        theme = mock.Mock()
+        theme.theme_dir_name = 'bragi'
+        theme.name = 'bragi'
+        helper_mock.get_current_theme.return_value = theme
+        helper_mock.get_project_root_name.return_value = 'lms'
+
+        parent_theme = mock.Mock()
+        parent_theme.theme_dir_name = 'default-theme'
+        parent_theme.name = 'default-theme'
+        parent_theme.template_dirs = Path('/ednx/var/themes/edx-platform/default-theme')
+        parent_mock.return_value = parent_theme
+
+        parent_theme_sources = EoxThemeFilesystemLoader.get_parent_theme_template_sources()
+        self.assertEqual(parent_theme_sources, parent_theme.template_dirs)

--- a/eox_theming/theming/template_loaders.py
+++ b/eox_theming/theming/template_loaders.py
@@ -2,16 +2,55 @@
 This stub module contains an empty extension point to modify the template loading
 This module's logic applies both to Mako and Django Templates
 """
-from eox_theming.edxapp_wrapper.loaders import get_openedx_theme_loader
+from eox_theming.edxapp_wrapper.loaders import get_openedx_theme_loader, get_theme_filesystem_loader
+from eox_theming.edxapp_wrapper.mako import get_mako_loader
 
+from eox_theming.configuration import ThemingConfiguration
+
+MakoLoader = get_mako_loader()
 OpenedxThemeLoader = get_openedx_theme_loader()
+ThemeFilesystemLoader = get_theme_filesystem_loader()
 
 
 class EoxThemeTemplateLoader(OpenedxThemeLoader):
     """
-    Emtpy for now, it allow for the extension of the ThemeTemplateLoader used
-    for comprehensive theming.
+    Overrided to use EoxThemeFilesystemLoader instead of platform ThemeFilesystemLoader.
 
     See: openedx.core.djangoapps.theming.template_loaders.py
     """
-    pass
+    def __init__(self, *args):
+        MakoLoader.__init__(self, EoxThemeFilesystemLoader(*args))
+
+
+class EoxThemeFilesystemLoader(ThemeFilesystemLoader):
+    """
+    Overrided to append parent theme dirs to the beginning so templates are looked up inside theme dir
+    and parent theme dir first.
+    """
+    def get_template_sources(self, template_name, template_dirs=None):
+        """
+        Append to the beginning of the template dirs the dir of the parent theme.
+        """
+        if not template_dirs:
+            template_dirs = self.engine.dirs
+
+        parent_theme_dirs = self.get_parent_theme_template_sources()
+
+        # append parent theme dirs to the beginning so templates are looked up inside theme dir first
+        if isinstance(parent_theme_dirs, list):
+            template_dirs = parent_theme_dirs + template_dirs
+
+        # on the next call, it will be appended to the beginning the site theme dir.
+        return list(super(EoxThemeFilesystemLoader, self).get_template_sources(template_name, template_dirs))
+
+    @staticmethod
+    def get_parent_theme_template_sources():
+        """
+        Return the template dirs of the parent theme.
+        """
+        default_theme = ThemingConfiguration.get_parent_or_default_theme()
+        template_paths = list()
+        if default_theme:
+            return default_theme.template_dirs
+
+        return template_paths

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -2,3 +2,5 @@ mock==2.0.0
 pylint==1.9.3
 pycodestyle==2.5.0
 coverage==4.5.1
+mako==1.0.2
+path.py==8.2.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 astroid==1.6.6            # via pylint
 backports.functools-lru-cache==1.5  # via astroid, isort, pylint
-configparser==3.8.1       # via pylint
+configparser==4.0.2       # via pylint
 coverage==4.5.1
 django==1.11.24
 enum34==1.1.6             # via astroid
@@ -14,9 +14,12 @@ funcsigs==1.0.2           # via mock
 futures==3.3.0 ; python_version < "3.0"
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.2  # via astroid
+mako==1.0.2
+markupsafe==1.1.1         # via mako
 mccabe==0.6.1             # via pylint
 mock==2.0.0
-pbr==5.4.2                # via mock
+path.py==8.2.1
+pbr==5.4.3                # via mock
 pycodestyle==2.5.0
 pylint==1.9.3
 pytz==2019.2              # via django


### PR DESCRIPTION
Adds the capability to inherit templates from parent theme.

How to test:

On devstack, install this version of eox-theming,

Add to the django settings:
```
THEME_OPTIONS = {
    "theme": {
        "name": "bragi",
        "parent": "gefion"
    }
}
```
Access to a site, i.e. site1.localhost:18000. Make sure that a django template is being loaded from bragi theme. (for instance, wiki/base.html)

Remove that template from the bragi theme, and then make sure that it is being loaded that template from the gefion theme.

Remove that template from the gefion theme, and then make sure that it is being loaded that template from platform code.

