### PR TITLE
Set the id of the site_theme object 

### DIFF
--- a/eox_theming/theming/middleware.py
+++ b/eox_theming/theming/middleware.py
@@ -28,4 +28,5 @@ class EoxThemeMiddleware(object):
                 site_id=1,
                 theme_dir_name=theme_name,
             )
+            current_theme.id = 1
             request.site_theme = current_theme


### PR DESCRIPTION
The object id of the site_theme is used in the current_request_has_associated_site_theme function (https://github.com/eduNEXT/edunext-platform/blob/master/openedx/core/djangoapps/theming/helpers.py#L237)

With this change, that function returns True as expected.
