### PR TITLE
Add JS to template

### DIFF
--- a/docs/extra_scripts.rst
+++ b/docs/extra_scripts.rst
@@ -1,0 +1,40 @@
+===============
+Extra scripts
+===============
+
+This feature allows the addition of multiple scripts (JavaScript) in any template.
+
+For instance if you want to have specific scripts to be rendered to the login page, add the path (regular expression) and the list of scripts to the settings in THEME_OPTIONS::
+
+    "THEME_OPTIONS": { "scripts": 
+                        { 
+                            "/login": [ 
+                                { 
+                                    "type": "external",
+                                    "media_type": "text/javascript",
+                                    "src": "https://www.test.com/js/myScript1.js" 
+                                }, 
+
+                                { 
+                                    "type": "inline",
+                                    "content": "alert('This is a test for the inline script');"
+                                }
+                            ]
+                        }
+                        ... 
+                    
+                    }
+
+Attributes
+------------------
+
+The attributes that can be specified for each script are:
+
+(1) **type**: to indicate whether is an *'external'* or *'inline'* script. This value is required.
+(2) **media_type**: whose options are *'module'* or *'text/javascript'*. This attribute has 'text/javascript' as its default value.
+(3) In case the script type is *'external'*, then is necessary to add the **src** attribute. If on the contrary, the script type is *'inline'*, then the **content** attribute with the script content is required.
+
+In case one of the attributes is missing (if the attribute is required) or is a invalid option, an error gets logged and the failing script will not be rendered, however all the other valid scripts will. 
+Here is an example of a logged error::
+    
+    2020-12-16 15:20:37,113 ERROR 2821 [eox_theming.theming.extra_scripts] [user None] extra_scripts.py:40 - Script could not get loaded. 'type' attribute is missing or is an invalid option.

--- a/eox_theming/tests/theming/test_extra_scripts.py
+++ b/eox_theming/tests/theming/test_extra_scripts.py
@@ -1,0 +1,107 @@
+"""
+Tests for the extra scripts.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.test import TestCase
+from mock import patch
+from path import Path
+from testfixtures import LogCapture
+
+from eox_theming.theming.extra_scripts import process_scripts, validate_script_attributes
+
+
+class TestsProcessExtraScripts(TestCase):
+    """ Tests for extra scripts"""
+
+    @patch('eox_theming.configuration.ThemingConfiguration.options')
+    def test_returned_process_scripts(self, themingConfig_mock):
+        """
+        Test process_scripts function returns a dictionary with all the valid scripts
+        in the correct order.
+        """
+        path = Path("/test")
+        themingConfig_mock.return_value = {
+            ".*/test": [
+                {
+                    "src": "https://www.test-external-script.com/js/myScript1.js",
+                    "type": "external",
+                    "media_type": "module"
+                },
+                {
+                    "content": "alert('This alert box was called with the onload event');",
+                    "type": "inline"
+                }
+            ]
+        }
+        test_scripts = [
+            {
+                "src": "https://www.test-external-script.com/js/myScript1.js",
+                "type": "external",
+                "media_type": "module"
+            },
+            {
+                "content": "alert('This alert box was called with the onload event');",
+                "type": "inline",
+                "media_type": "text/javascript"
+            },
+        ]
+
+        scripts = process_scripts(path)
+
+        self.assertEqual(test_scripts, scripts)
+
+    @patch('eox_theming.configuration.ThemingConfiguration')
+    def test_returned_(self, themingConfig_mock):
+        """
+        Test process_scripts function returns only the scripts that have a valid configuration.
+        """
+        path = Path("/test")
+        themingConfig_mock.return_value = {
+            ".*/test": [
+                {
+                    "content": "alert('This alert box was called with the onload event');",
+                    "type": "src"
+                }
+            ]
+        }
+
+        scripts = process_scripts(path)
+
+        self.assertEqual(None, scripts)
+
+    @patch('eox_theming.configuration.ThemingConfiguration')
+    def test_returned_path_scripts(self, themingConfig_mock):
+        """
+        Test process_scripts function returns only the scripts that match the current request path.
+        """
+        path = Path("/test")
+        themingConfig_mock.return_value = {
+            ".*/dashboard": [
+                {
+                    "src": "https://www.test-external-script.com/js/myScript1.js",
+                    "type": "external",
+                    "media_type": "text/javascript"
+                }
+            ]
+        }
+
+        scripts = process_scripts(path)
+
+        self.assertEqual(None, scripts)
+
+    def test_validate_script_attributes_fails_silently(self):
+        """
+        Test validate_script_attributes function logs error when a script has a missing/incorrect attribute.
+        """
+        values = {
+            "type": "external",
+            "media_type": "text/javascript"
+        }
+        log_message = "Script could not get loaded. 'src' attribute is missing."
+
+        with LogCapture() as log:
+            validate_script_attributes(values)
+            log.check(("eox_theming.theming.extra_scripts",
+                       "ERROR",
+                       log_message))

--- a/eox_theming/theming/context_processor.py
+++ b/eox_theming/theming/context_processor.py
@@ -4,13 +4,15 @@ This context processor is added to every request to render a mako or django temp
 It can be used using the theming.options(args) helper.
 """
 from eox_theming.configuration import ThemingConfiguration
+from eox_theming.theming.extra_scripts import process_scripts
 
 
-def eox_configuration(request):  # pylint: disable=unused-argument
+def eox_configuration(request):
     """
     It inserts a theming object with the options helper function
     This is the last processor to be run.
     """
     return {
+        'scripts': process_scripts(request.path_info),
         'theming': ThemingConfiguration,
     }

--- a/eox_theming/theming/extra_scripts.py
+++ b/eox_theming/theming/extra_scripts.py
@@ -1,0 +1,94 @@
+"""
+This function gets called during every request by the
+context processor to return all the custom scripts for a specific path.
+"""
+import logging
+import re
+
+import six
+
+from eox_theming.configuration import ThemingConfiguration
+
+logger = logging.getLogger(__name__)
+
+common_attributes = {'type': {'options': ['inline', 'external']},
+                     'media_type': {'options': ['module', 'text/javascript'], 'default': 1}}
+
+
+def validate_script_attributes(values):
+    """
+    Validate common attributes for external and inline scripts.
+    """
+    script_attributes = {}
+
+    # Validate common attributes for external and inline scripts
+    for key, attr_values in common_attributes.items():
+
+        value = values.get(key)
+
+        try:
+            if value is not None:
+                attr_values['options'].index(value.lower())
+
+                script_attributes[key] = value.lower()
+            else:
+                default = attr_values['default']
+
+                script_attributes[key] = attr_values['options'][default]
+
+        except Exception:  # pylint: disable=broad-except
+            logger.error("Script could not get loaded. '%s' attribute is missing or is an invalid option.", key)
+
+            return None
+
+    # Validate according to the script type
+    attr = 'src'
+    if script_attributes['type'] == 'inline':
+        attr = 'content'
+
+    script_attributes = check_attribute(values, script_attributes, attr)
+
+    return script_attributes
+
+
+def check_attribute(values, script_attributes, attribute):
+    """
+    Validate the existence of an specific attribute.
+    """
+    try:
+        script_attributes[attribute] = values[attribute]
+    except Exception:  # pylint: disable=broad-except
+        logger.error("Script could not get loaded. '%s' attribute is missing.", attribute)
+
+        return None
+
+    return script_attributes
+
+
+def process_scripts(path):
+    """
+    Process and loads all the extra scripts for the template
+    rendered during the request.
+    """
+    scripts = ThemingConfiguration.options('scripts', default={})
+
+    for regex, values in six.iteritems(scripts):
+
+        regex_path_match = re.compile(regex)
+
+        if regex_path_match.match(path):
+
+            scripts = []
+
+            for script in values:
+
+                validated_script = validate_script_attributes(script)
+
+                if validated_script:
+
+                    scripts.append(validated_script)
+
+            if scripts:
+                return scripts
+
+    return None

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -8,3 +8,4 @@ pycodestyle==2.5.0
 coverage==4.5.1
 mako==1.0.2
 path.py==8.2.1
+testfixtures

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -24,4 +24,5 @@ pylint==1.9.3             # via -c requirements/constraints.txt, -r requirements
 pytz==2020.1              # via -r requirements/base.txt, django
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.15.0               # via astroid, mock, pylint, singledispatch
+testfixtures==6.4.3       # via -c requirements/constraints.txt, -r requirements/test.in
 wrapt==1.12.1             # via astroid


### PR DESCRIPTION
This PR allows adding custom scripts for each template.

For example: to add a specific script to the login template, add the path and the configurations of the script
to the settings.
`    "THEME_OPTIONS": {
        "scripts": {
            "/login": [
                {
                    "type": "external",
                    "src": "https://www.test.com/js/myScript1.js"
                },
                {
                    "type": "inline",
                    "content": "alert('This alert box was called with the onload event');"
                }]}`

The attributes that can be specified are:
-  type: to indicate whether is an 'external' or 'inline' script
- media_type : 'module' or  'text/javascript' 
The media_type attribute has  'text/javascript' as its default value.

If the script type is 'external', then is necessary to add the 'src' attribute.
if the script type is 'inline', then the 'content' attribute must have the script.