### PR TITLE
feat: Add tests for py3.8 and drop support for Ironwood

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,13 @@ workflows:
               only: /v?[0-9]+(\.[0-9]+)*/
           matrix:
             parameters:
-              python_version: ["2.7", "3.5"]
-              django_version: ["django111", "django22"]
+              python_version: ["3.5", "3.8"]
+              debian_version: ["stretch", "buster"]
             exclude:
-              - python_version: "2.7"
-                django_version: "django22"
+              - python_version: "3.8"
+                debian_version: "stretch"
+              - python_version: "3.5"
+                debian_version: "buster"
       - pypi:
           requires:
             - test
@@ -32,6 +34,7 @@ jobs:
     parameters:
       django_version:
         type: string
+        default: django22
       python_version:
         type: string
       debian_version:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in
 	$(PIP_COMPILE) -o requirements/tox.txt requirements/tox.in
 
-	grep -e "^django==" requirements/test.txt > requirements/django.txt
+	grep -e "^django==" requirements/test.txt > requirements/django22.txt
 	sed '/^[dD]jango==/d;' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
 

--- a/eox_theming/apps.py
+++ b/eox_theming/apps.py
@@ -49,7 +49,7 @@ class EoxThemingConfig(AppConfig):
         Setup mako lookup directories.
         See: common.djangoapps.edxmako.apps.py
         """
-        from eox_theming.theming.paths import add_lookup, clear_lookups
+        from eox_theming.theming.paths import add_lookup, clear_lookups  # pylint: disable=import-outside-toplevel
         for backend in settings.TEMPLATES:
             if 'edxmako' not in backend['BACKEND']:
                 continue
@@ -65,9 +65,9 @@ class EoxThemingConfig(AppConfig):
         """
         Method to apply monkey patches over openedX classes
         """
-        from eox_theming.edxapp_wrapper.theming_helpers import get_theming_helpers_dirs, get_theming_helpers
-        from eox_theming import configuration
-        from eox_theming.theming.patches import EoxTheme
+        from eox_theming.edxapp_wrapper.theming_helpers import get_theming_helpers_dirs, get_theming_helpers    # pylint: disable=import-outside-toplevel
+        from eox_theming import configuration    # pylint: disable=import-outside-toplevel
+        from eox_theming.theming.patches import EoxTheme    # pylint: disable=import-outside-toplevel
 
         theming_helpers = get_theming_helpers()
         theming_helpers_dirs = get_theming_helpers_dirs()

--- a/eox_theming/configuration/__init__.py
+++ b/eox_theming/configuration/__init__.py
@@ -12,7 +12,7 @@ LOG = logging.getLogger(__name__)
 Theme = get_theme_class()
 
 
-class ThemingConfiguration(object):
+class ThemingConfiguration:
     """
     This class must handle all the calls to the diferential settings a theme will be allowed to use
     """

--- a/eox_theming/edxapp_wrapper/backends/j_storage.py
+++ b/eox_theming/edxapp_wrapper/backends/j_storage.py
@@ -1,7 +1,7 @@
 """
 Simple backend that returns the platform's SiteTheme model
 """
-from openedx.core.djangoapps.theming.storage import (  # pylint: disable=import-error
+from openedx.core.djangoapps.theming.storage import (  # pylint: disable=no-name-in-module,import-error
     ThemeCachedFilesMixin,
     ThemePipelineMixin,
     ThemeStorage,

--- a/eox_theming/settings/test.py
+++ b/eox_theming/settings/test.py
@@ -7,9 +7,8 @@ from __future__ import unicode_literals
 from .common import *  # pylint: disable=wildcard-import
 
 
-class SettingsClass(object):
+class SettingsClass:
     """ dummy settings class """
-    pass
 
 
 SETTINGS = SettingsClass()

--- a/eox_theming/templatetags/eox_theming.py
+++ b/eox_theming/templatetags/eox_theming.py
@@ -10,7 +10,7 @@ from django import template
 
 from eox_theming.configuration import ThemingConfiguration
 
-register = template.Library()  # pylint: disable=invalid-name
+register = template.Library()
 
 
 class ThemingOptionsNode(template.Node):

--- a/eox_theming/test_utils.py
+++ b/eox_theming/test_utils.py
@@ -3,7 +3,7 @@ Test util modules
 """
 
 
-class TestThemingHelpersDirs(object):
+class TestThemingHelpersDirs:
     """
     Theme class for helpers_dirs
     """

--- a/eox_theming/tests/theming/test_middleware.py
+++ b/eox_theming/tests/theming/test_middleware.py
@@ -19,7 +19,7 @@ class TestsEoxThemeMiddleware(TestCase):
         site_theme = mock.Mock()
         module_mock.return_value.return_value = site_theme
 
-        from eox_theming.theming.middleware import EoxThemeMiddleware
+        from eox_theming.theming.middleware import EoxThemeMiddleware  # pylint: disable=import-outside-toplevel
         EoxThemeMiddleware().process_request(request)
 
         self.assertEqual(site_theme, request.site_theme)  # pylint: disable=no-member

--- a/eox_theming/theming/finders.py
+++ b/eox_theming/theming/finders.py
@@ -31,4 +31,3 @@ class EoxThemeFilesFinder(OpenedxThemeFinder):
 
     See: openedx/core/djangoapps/theming/finders.py
     """
-    pass

--- a/eox_theming/theming/storage.py
+++ b/eox_theming/theming/storage.py
@@ -70,7 +70,7 @@ class EoxThemeStorage(OpenedxThemeStorage):
         return super(EoxThemeStorage, self).url(name)
 
 
-class AbsoluteUrlAssetsMixin(object):
+class AbsoluteUrlAssetsMixin:
     """
     Mixin that overrides the url method on storages
     """
@@ -186,4 +186,3 @@ class EoxDevelopmentStorage(
     that provide additional functionality. We use this version for development,
     so that we can skip packaging and optimization.
     """
-    pass

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,5 +4,5 @@
 #
 #    make upgrade
 #
-django==1.11.29           # via -r requirements/base.in
-pytz==2020.1              # via django
+django==2.2.16            # via -r requirements/base.in
+pytz==2021.3              # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,12 +8,8 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# Already in python3 standard library
-futures==3.3.0; python_version == "2.7"
-
-# TODO: Add constraint explanation
-pylint==1.9.3
-pycodestyle==2.5.0
+# Drops support for python 3.5
+pylint<2.7.0
 
 # Keep same platform version
 testfixtures==6.4.3

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,0 @@
-django==1.11.29           # via -r requirements/base.txt, -r requirements/test.in

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,9 +3,10 @@
 
 Django
 mock==2.0.0
-pylint==1.9.3
+pylint==2.5.0
+astroid==2.4.2
 pycodestyle==2.5.0
-coverage==4.5.1
+coverage==4.5.2
 mako==1.0.2
 path.py==8.2.1
 testfixtures

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,25 +4,20 @@
 #
 #    make upgrade
 #
-astroid==1.6.6            # via pylint
-backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
-configparser==4.0.2       # via pylint
-coverage==4.5.1           # via -r requirements/test.in
-enum34==1.1.10            # via astroid
-funcsigs==1.0.2           # via mock
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, isort
+astroid==2.4.2              # via pylint
+coverage==4.5.2           # via -r requirements/test.in
 isort==4.3.21             # via pylint
-lazy-object-proxy==1.5.1  # via astroid
+lazy-object-proxy==1.4.3  # via astroid
 mako==1.0.2               # via -r requirements/test.in
 markupsafe==1.1.1         # via mako
 mccabe==0.6.1             # via pylint
 mock==2.0.0               # via -r requirements/test.in
 path.py==8.2.1            # via -r requirements/test.in
-pbr==5.5.0                # via mock
+pbr==5.6.0                # via mock
 pycodestyle==2.5.0        # via -c requirements/constraints.txt, -r requirements/test.in
-pylint==1.9.3             # via -c requirements/constraints.txt, -r requirements/test.in
-pytz==2020.1              # via -r requirements/base.txt, django
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.15.0               # via astroid, mock, pylint, singledispatch
+pylint==2.5.0             # via -c requirements/constraints.txt, -r requirements/test.in
+pytz==2021.3              # via -r requirements/base.txt, django
+six==1.16.0               # via mock
 testfixtures==6.4.3       # via -c requirements/constraints.txt, -r requirements/test.in
+toml==0.10.2              # via pylint
 wrapt==1.12.1             # via astroid

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
-envlist = py27-django111,py35-django{111,22}
+envlist = py{35,38}-django22
 
 
 [testenv]
 envdir=
     # Use the same environment for all commands running under a specific python version
-    py27: {toxworkdir}/py27
     py35: {toxworkdir}/py35
+    py38: {toxworkdir}/py38
 
 deps =
-    django111: -r requirements/django.txt
     django22: -r requirements/django22.txt
     -rrequirements/test.txt
 commands =


### PR DESCRIPTION
**Changes**
- Upgrade requirements 
- Delete settings for the tests with django1.11
- Delete settings for the tests with python2.7
- Delete requirement file: Django
- Add tests for python3.8 and  Debian versions: stretch and buster
- Since Pylint got upgraded to 2.5.0 (older versions do not support python3.8), some new code-style errors appeared and were properly fixed

