### PR TITLE
perf: adding a source faster compatibility source for eox-tenant

### DIFF
--- a/eox_theming/edxapp_wrapper/config_sources.py
+++ b/eox_theming/edxapp_wrapper/config_sources.py
@@ -48,6 +48,19 @@ def from_eox_tenant_microsite_v0(*args):
     return configuration_helpers.get_value(key, None)
 
 
+def from_eox_tenant_microsite_v2(*args):
+    """
+    This source does the v0 compatibility but uses direct readings from the settings
+    dict instead of calls to configuration_helpers.
+    """
+    key = args[-1]
+    try:
+        value = getattr(settings, key, None)
+    except (AttributeError, KeyError):
+        value = None
+    return value
+
+
 def from_eox_tenant_config_lms(*args):
     """
     Given that the eox_microsite version loads all the config variables into

--- a/eox_theming/settings/common.py
+++ b/eox_theming/settings/common.py
@@ -81,6 +81,7 @@ def plugin_settings(settings):
         'from_eox_tenant_config_theming',
         'from_eox_tenant_config_lms',
         'from_eox_tenant_microsite_v1',
+        'from_eox_tenant_microsite_v2',
         'from_eox_tenant_microsite_v0',
         'from_site_config',
         'from_django_settings',


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR adds a new config source. This source is a faster implementation of the microsite_V0.

- V0, will remove a key that is unused by the current version of control center and will then pass that call to configuration_helpers.
- V1 will not remove the key.
- V2 will remove the key, but then make a faster call to django settings directly.

## Testing instructions

first, add the following config to lms.env.json:

```json
"EOX_THEMING_CONFIG_SOURCES":[
  "from_eox_tenant_microsite_v2",
  "from_django_settings"
],
```
when using a profiler, the call went from:

`Per call: 6.056e-05 | config_sources.py:42(from_eox_tenant_microsite_v0)`

to

`Per call: 7.453e-06 | config_sources.py:51(from_eox_tenant_microsite_v2`)

One order of magnitude faster.


## Checklist for Merge

- [x] Tested in a remote environment -> I suppose you need to apply this in order to test @Alec4r 
- [x] Updated documentation N/A
- [x] Rebased master/main N/
- [x] Squashed commits N/


<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->