### PR TITLE
feat: override get_dirs method

### DIFF
--- a/eox_theming/theming/template_loaders.py
+++ b/eox_theming/theming/template_loaders.py
@@ -17,6 +17,7 @@ class EoxThemeTemplateLoader(OpenedxThemeLoader):
 
     See: openedx.core.djangoapps.theming.template_loaders.py
     """
+
     def __init__(self, *args):
         MakoLoader.__init__(self, EoxThemeFilesystemLoader(*args))
 
@@ -79,3 +80,17 @@ class EoxThemeFilesystemLoader(ThemeFilesystemLoader):
             return grandparent_theme.template_dirs
 
         return template_paths
+
+    def get_dirs(self):
+        """This overrides the default get_dirs method from django
+        https://github.com/django/django/blob/3.2/django/template/loaders/filesystem.py#L18
+        due to the django implementation depends on the initialization process that is performed by
+        the sub-class ThemeFilesystemLoader
+        https://github.com/eduNEXT/edunext-platform/blob/open-release/maple.master/openedx/core/djangoapps/theming/template_loaders.py#L30
+        however that implementation is cached and doesn't allow to get the right values during the execution time.
+
+        Finally this returns the result of the `get_theme_template_sources` method
+        https://github.com/eduNEXT/edunext-platform/blob/master/openedx/core/djangoapps/theming/template_loaders.py#L39
+        instead of using the cached values of self.dirs on runtime.
+        """
+        return ThemeFilesystemLoader.get_theme_template_sources()


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This overrides the default get_dirs method from django
        https://github.com/django/django/blob/3.2/django/template/loaders/filesystem.py#L18
        due to the django implementation depends on the initialization process that is performed by
        the sub-class ThemeFilesystemLoader
        https://github.com/eduNEXT/edunext-platform/blob/open-release/maple.master/openedx/core/djangoapps/theming/template_loaders.py#L30
        however that implementation is cached and doesn't allow to get the right values during the execution time.
        So this method implements the same logic as the method(get_theme_template_sources) that is called in the
        initialization method to get the right theme on runtime.
        https://github.com/eduNEXT/edunext-platform/blob/master/openedx/core/djangoapps/theming/template_loaders.py#L39

## Testing instructions

The issue cannot be replicated easily in other environments, so all this step are based on the nelc dev kit environment
##### Replicate issue
1. Checkout maple branch
2.  restart your local server (This step deletes the cache)
3. Go to http://dga-v2.local.overhang.io:8000/
4.  Go to http://local.overhang.io:8000/logout


https://github.com/eduNEXT/eox-theming/assets/36200299/ead96761-f5de-485f-9ecd-fbe626f4786c

#### Solution

1. Checkout and/get_dirs_on_runtime branch
2.  restart your local server (This step deletes the cache)
3. Go to http://dga-v2.local.overhang.io:8000/
4.  Go to http://local.overhang.io:8000/logout

https://github.com/eduNEXT/eox-theming/assets/36200299/931aa77b-5872-4de5-ac1b-0dd8d131448a


