### PR TITLE
fix: Improved handling of empty directories in get_dirs method

### DIFF
--- a/eox_theming/theming/template_loaders.py
+++ b/eox_theming/theming/template_loaders.py
@@ -93,4 +93,6 @@ class EoxThemeFilesystemLoader(ThemeFilesystemLoader):
         https://github.com/eduNEXT/edunext-platform/blob/master/openedx/core/djangoapps/theming/template_loaders.py#L39
         instead of using the cached values of self.dirs on runtime.
         """
-        return ThemeFilesystemLoader.get_theme_template_sources()
+        theme_dirs = ThemeFilesystemLoader.get_theme_template_sources()
+
+        return theme_dirs if theme_dirs else super().get_dirs()


### PR DESCRIPTION
## Description
@eduNEXT/dedalo @andrey-canon This PR wants to enhance the way in that the method works with null or empty values.
This is a previous used logic, which allows us to get specific values when they are available or to fall back to a default value in case there is no data, null, or empty data.