### PR TITLE
perf: add redwood compatibility

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v5
+      - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tutor_version: ["<17.0.0", "<18.0.0"]
+        tutor_version: ["<17.0.0", "<18.0.0", "<19.0.0"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         python -m build --sdist --wheel --outdir dist/ .
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@v1.8.10
+      uses: pypa/gh-action-pypi-publish@v1.9.0
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v7.1.1 - 2024-07-17
+
+### Changed
+- **Update requirements**: The `requirements` for both the plugin and the `GitHub workflows` have been upgraded.
+
+### Fixed
+- **Sending wrong footer in the Wiki**: The issue occurred when only the template directory for the current theme was being returned. If this directory didn't exist, the default template was returned instead ([issue #9](https://github.com/eduNEXT/eox-release/issues/9)). This problem was resolved by executing the `get_theme_template_sources` method from the `EoxThemeFilesystemLoader`, which retrieves the template directories not only for the current theme but also for its parent and grandparent themes.
+
 ## v7.1.0 - 2024-03-19
 
 ### [7.1.0](https://github.com/eduNEXT/eox-theming/compare/v7.0.0...v7.1.0) (2024-03-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Update requirements**: The `requirements` for both the plugin and the `GitHub workflows` have been upgraded.
 
 ### Fixed
-- **Sending wrong footer in the Wiki**: The issue occurred when only the template directory for the current theme was being returned. If this directory didn't exist, the default template was returned instead ([issue #9](https://github.com/eduNEXT/eox-release/issues/9)). This problem was resolved by executing the `get_theme_template_sources` method from the `EoxThemeFilesystemLoader`, which retrieves the template directories not only for the current theme but also for its parent and grandparent themes.
+- **Django templates were not found according to the THEME_OPTIONS definition**: The issue occurred because the function `get_template_sources` only returns the directory for the current theme, then if this directory doesn't exist, the default template is returned instead ([issue #9](https://github.com/eduNEXT/eox-release/issues/9)). This problem was resolved by executing the `get_theme_template_sources` method from the `EoxThemeFilesystemLoader`, which retrieves the template directories not only for the current theme but also for its parent and grandparent themes.
 
 ## v7.1.0 - 2024-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v7.1.1 - 2024-07-17
+## v7.2.0 - 2024-07-17
 
 ### Changed
-- **Update requirements**: The `requirements` for both the plugin and the `GitHub workflows` have been upgraded.
+- **Redwood Support**: The `requirements` have been updated in line with the `edx-platform` Redwood release. Additionally, the `GitHub workflows` dependencies have been upgraded to the latest functional versions, and various documentation sections have been revised.
 
 ### Fixed
-- **Django templates were not found according to the THEME_OPTIONS definition**: The issue occurred because the function `get_template_sources` only returns the directory for the current theme, then if this directory doesn't exist, the default template is returned instead ([issue #9](https://github.com/eduNEXT/eox-release/issues/9)). This problem was resolved by executing the `get_theme_template_sources` method from the `EoxThemeFilesystemLoader`, which retrieves the template directories not only for the current theme but also for its parent and grandparent themes.
+- **Django templates were not found according to the THEME_OPTIONS definition**: The issue occurred because the `get_template_sources` method only returns the directory for the current theme, then if this directory doesn't exist, the default template is returned instead ([issue #9](https://github.com/eduNEXT/eox-release/issues/9)). This problem was resolved by executing the `get_theme_template_sources` method from the `EoxThemeFilesystemLoader`, which retrieves the template directories not only for the current theme but also for its parent and grandparent themes.
 
 ## v7.1.0 - 2024-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v7.2.0 - 2024-07-17
+## v7.2.0 - 2024-07-24
 
 ### Changed
 - **Redwood Support**: The `requirements` have been updated in line with the `edx-platform` Redwood release. Additionally, the `GitHub workflows` dependencies have been upgraded to the latest functional versions, and various documentation sections have been revised.
 
 ### Fixed
-- **Django templates were not found according to the THEME_OPTIONS definition**: The issue occurred because the `get_template_sources` method only returns the directory for the current theme, then if this directory doesn't exist, the default template is returned instead ([issue #9](https://github.com/eduNEXT/eox-release/issues/9)). This problem was resolved by executing the `get_theme_template_sources` method from the `EoxThemeFilesystemLoader`, which retrieves the template directories not only for the current theme but also for its parent and grandparent themes.
+- **Django templates were not found according to the THEME_OPTIONS definition**: The issue occurred because the `get_theme_template_sources` method only returns the directory for the current theme, then if this directory doesn't exist, the default template is returned instead ([issue #9](https://github.com/eduNEXT/eox-release/issues/9)). This problem was resolved by executing the `get_theme_template_sources` method from the `EoxThemeFilesystemLoader`, which retrieves the template directories not only for the current theme but also for its parent and grandparent themes.
 
 ## v7.1.0 - 2024-03-19
 

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,9 @@ Compatibility Notes
 +------------------+--------------+
 | Palm             | >= 6.0       |
 +------------------+--------------+
-| Quince, Redwood  | >= 7.0       |
+| Quince           | >= 7.0       |
++------------------+--------------+
+| Redwood          | >= 7.0       |
 +------------------+--------------+
 
 * From Lilac version Django 2.2 is not supported, you should use Django 3.2 and eox-tenant >=4.0.
@@ -55,18 +57,19 @@ Pre-requirements
 - Ensure you have a theme or themes following the `Changing Themes guide <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/index.html>`_ and compile them so they are accessible for the platform
 
 .. note::
+
     In order to simplify this process, we encourage the use of ``Distro Tutor Plugin`` for managing the addition and compilation of custom themes: `README of Distro <https://github.com/eduNEXT/tutor-contrib-edunext-distro?tab=readme-ov-file#themes>`_
 
-Open edX devstack
------------------
+Using Open edX devstack
+-----------------------
 
 #. Clone this repo in the ``src`` folder of your devstack.
 #. Open a new ``lms/devstack`` shell.
 #. Install the plugin as follows: ``pip install -e /path/to/your/src/folder``
 #. Restart lms/cms services.
 
-Tutor
------
+Using Tutor
+-----------
 
 #. Install the plugin adding it to ``OPENEDX_EXTRA_PIP_REQUIREMENTS`` in the ``config.yml``.
    
@@ -100,8 +103,6 @@ Next,  with ``eox-tenant`` create a new ``route`` or modify an existing one to p
         }
     }
 
-**Using Tutor**
-
 If you chose to use ``Distro Tutor Plugin``, just follow the instructions given in the `Themes section <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/master/README.md#themes>`_. Otherwise, if you are doing the process manually, follow this steps:
 
 #. Add the following settings to your environment file ``env/apps/openedx/settings/lms/[development | production].py``:
@@ -128,9 +129,8 @@ If you chose to use ``Distro Tutor Plugin``, just follow the instructions given 
 
 #. Compile the before added themes according to you are using a `production environment <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/a63e585b9bc3089e00623974c8b365ea874f0a2b/README.md?plain=1#L219>`_ or a `dev environment <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/a63e585b9bc3089e00623974c8b365ea874f0a2b/README.md?plain=1#L234>`_
 
-**Using devstack**
 
-Include the follow configuration in devstack.py:
+#. Ensure is included the follow configuration in `devstack.py` in `eox-theming`:
 
 .. code-block:: python
 
@@ -152,6 +152,7 @@ Include the follow configuration in devstack.py:
 
         settings.STATICFILES_STORAGE = 'eox_theming.theming.storage.EoxDevelopmentStorage'
 
+        # If you are using devstack, ensure this file contains the following
         from lms.envs.common import _make_mako_template_dirs # pylint: disable=import-error
         settings.ENABLE_COMPREHENSIVE_THEMING = True
         settings.COMPREHENSIVE_THEME_DIRS = [
@@ -160,8 +161,9 @@ Include the follow configuration in devstack.py:
         settings.TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
         settings.derive_settings("lms.envs.devstack")
 
-
-Note that in ``COMPREHENSIVE_THEME_DIRS`` it must contain a list of directories where the folders of the themes to be tested are located.
+.. note::
+    
+    Note that in ``COMPREHENSIVE_THEME_DIRS`` it must contain a list of directories where the folders of the themes to be tested are located.
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,15 @@ Compatibility Notes
 | Redwood          | >= 7.0       |
 +------------------+--------------+
 
-* From Lilac version Django 2.2 is not supported, you should use Django 3.2 and eox-tenant >=4.0.
+⚠️ From Lilac version Django 2.2 is not supported, you should use Django 3.2 and eox-tenant >=4.0.
+
+The plugin is configured for the latest release (Redwood). If you need compatibility for previous releases, go to the README of the relevant version tag and if it is necessary you can change the configuration in ``eox_theming/settings/common.py``.
+
+🚨 If the release you are looking for is not listed, please note:
+
+- If the Open edX release is compatible with the current eox-theming version (see `Compatibility Notes <https://github.com/eduNEXT/eox-theming?tab=readme-ov-file#compatibility-notes>`_), the default configuration is sufficient.
+- If incompatible, you can refer to the README from the relevant version tag for configuration details (e.g., `v2.0.0 README <https://github.com/eduNEXT/eox-theming/blob/v2.0.0/README.rst>`_).
+
 
 ************
 Installation
@@ -56,17 +64,9 @@ Pre-requirements
 - A compatible version of `eox-tenant <https://github.com/eduNEXT/eox-tenant>`_
 - Ensure you have a theme or themes following the `Changing Themes guide <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/index.html>`_ and compile them so they are accessible for the platform
 
-.. note::
+**NOTE**
 
-    In order to simplify this process, we encourage the use of ``Distro Tutor Plugin`` for managing the addition and compilation of custom themes: `README of Distro <https://github.com/eduNEXT/tutor-contrib-edunext-distro?tab=readme-ov-file#themes>`_
-
-Using Open edX devstack
------------------------
-
-#. Clone this repo in the ``src`` folder of your devstack.
-#. Open a new ``lms/devstack`` shell.
-#. Install the plugin as follows: ``pip install -e /path/to/your/src/folder``
-#. Restart lms/cms services.
+In order to simplify this process, we encourage the use of ``Distro Tutor Plugin`` for managing the addition and compilation of custom themes: `README of Distro <https://github.com/eduNEXT/tutor-contrib-edunext-distro?tab=readme-ov-file#themes>`_
 
 Using Tutor
 -----------
@@ -97,8 +97,8 @@ Next,  with ``eox-tenant`` create a new ``route`` or modify an existing one to p
         "THEME_OPTIONS": {
             "theme": {
                 "name":"my-theme-1",
-                "parent":"my-theme-2"
-                "grandparent":"my-theme-3",
+                "parent":"my-theme-2",
+                "grandparent":"my-theme-3"
             }
         }
     }
@@ -120,50 +120,39 @@ If you chose to use ``Distro Tutor Plugin``, just follow the instructions given 
    
        ################## EOX_THEMING ##################
        if "EOX_THEMING_DEFAULT_THEME_NAME" in locals() and EOX_THEMING_DEFAULT_THEME_NAME:
-       from lms.envs.common import _make_mako_template_dirs  # pylint: disable=import-error
-   
-   
-       ENABLE_COMPREHENSIVE_THEMING = True
-       TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
-       derive_settings("lms.envs.[devstack | production]")  # lms.envs.devstack or lms.envs.production
+           from lms.envs.common import _make_mako_template_dirs  # pylint: disable=import-error
+           ENABLE_COMPREHENSIVE_THEMING = True
+           TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
+           derive_settings("lms.envs.[devstack | production]")  # lms.envs.devstack or lms.envs.production
 
 #. Compile the before added themes according to you are using a `production environment <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/a63e585b9bc3089e00623974c8b365ea874f0a2b/README.md?plain=1#L219>`_ or a `dev environment <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/a63e585b9bc3089e00623974c8b365ea874f0a2b/README.md?plain=1#L234>`_
 
 
 #. Ensure is included the follow configuration in `devstack.py` in `eox-theming`:
 
-.. code-block:: python
+    .. code-block:: python
 
-    """
-    Production Django settings for eox_theming project.
-    """
-
-    from __future__ import unicode_literals
-
-
-    def plugin_settings(settings):
         """
-        Set of plugin settings used by the Open Edx platform.
-        More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
+        Production Django settings for eox_theming project.
         """
-        settings.STATICFILES_FINDERS = [
-            'eox_theming.theming.finders.EoxThemeFilesFinder',
-        ] + settings.STATICFILES_FINDERS
 
-        settings.STATICFILES_STORAGE = 'eox_theming.theming.storage.EoxDevelopmentStorage'
+        from __future__ import unicode_literals
 
-        # If you are using devstack, ensure this file contains the following
-        from lms.envs.common import _make_mako_template_dirs # pylint: disable=import-error
-        settings.ENABLE_COMPREHENSIVE_THEMING = True
-        settings.COMPREHENSIVE_THEME_DIRS = [
-            '/edx/src/themes/ednx-test-themes/edx-platform/',
-        ]
-        settings.TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
-        settings.derive_settings("lms.envs.devstack")
 
-.. note::
-    
-    Note that in ``COMPREHENSIVE_THEME_DIRS`` it must contain a list of directories where the folders of the themes to be tested are located.
+        def plugin_settings(settings):
+            """
+            Set of plugin settings used by the Open Edx platform.
+            More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
+            """
+            settings.STATICFILES_FINDERS = [
+                'eox_theming.theming.finders.EoxThemeFilesFinder',
+            ] + settings.STATICFILES_FINDERS
+
+            settings.STATICFILES_STORAGE = 'eox_theming.theming.storage.EoxDevelopmentStorage'
+
+**NOTE** 
+
+In ``COMPREHENSIVE_THEME_DIRS`` it must contain a list of directories where the folders of the themes to be tested are located.
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -1,115 +1,134 @@
-=======================
-Open edX Theming Plugin
-=======================
+===========
+EOX Theming
+===========
+|Maintainance Badge| |Test Badge| |PyPI Badge|
 
-Features
---------
+.. |Maintainance Badge| image:: https://img.shields.io/badge/Status-Maintained-brightgreen
+   :alt: Maintainance Status
+.. |Test Badge| image:: https://img.shields.io/github/actions/workflow/status/edunext/eox-theming/.github%2Fworkflows%2Ftests.yml?label=Test
+   :alt: GitHub Actions Workflow Test Status
+.. |PyPI Badge| image:: https://img.shields.io/pypi/v/eox-theming?label=PyPI
+   :alt: PyPI - Version
 
-This plugin provides a stable place from where to create and launch your openedx theme.
+********
+Overview
+********
 
+Eox theming is a plugin for `Open edX <https://github.com/openedx/edx-platform>`_, and part of the Edunext Open Extensiones (aka EOX) that provides a stable place from where to create and launch themes to the Open edX platform.
 
+If you are looking for professional development or support with multitenancy or multi-sites in the Open edX platform, you can reach out to sales@edunext.co
+
+*******************
 Compatibility Notes
--------------------
+*******************
 
-+------------------+---------------------+
-| Open edX Release |        Version      |
-+==================+=====================+
-|     Juniper      |       >= 1.0 < 2.0  |
-+------------------+---------------------+
-|       Koa        |       >= 2.0 < 3.0  |
-+------------------+---------------------+
-|      Lilac       |       >= 2.0        |
-+------------------+---------------------+
-|      Maple       |       >= 3.0        |
-+------------------+---------------------+
-|      Nutmeg      |       >= 4.0        |
-+------------------+---------------------+
-|      Olive       |       >= 5.0        |
-+------------------+---------------------+
-|      Palm        |       >= 6.0        |
-+------------------+---------------------+
-|      Quince      |       >= 7.0        |
-+------------------+---------------------+
++------------------+--------------+
+| Open edX Release | Version      |
++==================+==============+
+| Juniper          | >= 1.0 < 2.0 |
++------------------+--------------+
+| Koa              | >= 2.0 < 3.0 |
++------------------+--------------+
+| Lilac            | >= 2.0       |
++------------------+--------------+
+| Maple            | >= 3.0       |
++------------------+--------------+
+| Nutmeg           | >= 4.0       |
++------------------+--------------+
+| Olive            | >= 5.0       |
++------------------+--------------+
+| Palm             | >= 6.0       |
++------------------+--------------+
+| Quince, Redwood  | >= 7.0       |
++------------------+--------------+
 
-**NOTE**: From Lilac version Django 2.2 is not supported, you should use Django 3.2 and eox-tenant >=4.0.
+* From Lilac version Django 2.2 is not supported, you should use Django 3.2 and eox-tenant >=4.0.
 
-The following changes to the plugin settings are necessary. If the release you are looking for is
-not listed, then the accumulation of changes from previous releases is enough.
-
-Juniper
-~~~~~~~
-
-.. code-block:: bash
-
-    EOX_THEMING_BASE_FINDER_BACKEND = 'eox_theming.edxapp_wrapper.backends.j_finders'
-    EOX_THEMING_BASE_LOADER_BACKEND = 'eox_theming.edxapp_wrapper.backends.j_loaders'
-    EOX_THEMING_SITE_THEME_BACKEND = 'eox_theming.edxapp_wrapper.backends.j_models'
-    EOX_THEMING_CONFIGURATION_HELPER_BACKEND = 'eox_theming.edxapp_wrapper.backends.j_configuration_helpers'
-    EOX_THEMING_THEMING_HELPER_BACKEND = 'eox_theming.edxapp_wrapper.backends.j_theming_helpers'
-    EOX_THEMING_STORAGE_BACKEND = 'eox_theming.edxapp_wrapper.backends.j_storage'
-    STATICFILES_STORAGE = 'eox_theming.theming.storage.EoxProductionStorage'
-    EOX_THEMING_EDXMAKO_BACKEND = 'eox_theming.edxapp_wrapper.backends.j_mako'
-
-
-Koa (optional)**
-~~~~~~~~~~~~~~~~
-
-.. code-block:: bash
-
-    EOX_THEMING_STORAGE_BACKEND = 'eox_theming.edxapp_wrapper.backends.l_storage'
-    EOX_THEMING_EDXMAKO_BACKEND = 'eox_theming.edxapp_wrapper.backends.l_mako'
-
-
-Lilac - Maple - Nutmeg - Olive - Palm - Quince
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: bash
-
-    EOX_THEMING_STORAGE_BACKEND = 'eox_theming.edxapp_wrapper.backends.l_storage'
-    EOX_THEMING_EDXMAKO_BACKEND = 'eox_theming.edxapp_wrapper.backends.l_mako'
-
-
-Those settings can be changed in ``eox_theming/settings/common.py`` or, for example, in ansible configurations.
-
-**NOTE**: the current ``common.py`` works with Open edX lilac version.
-
+************
 Installation
-------------
+************
+
+Pre-requirements
+----------------
+
+- A compatible version of `eox-tenant <https://github.com/eduNEXT/eox-tenant>`_
+- Ensure you have a theme or themes following the `Changing Themes guide <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/index.html>`_ and compile them so they are accessible for the platform
+
+.. note::
+    In order to simplify this process, we encourage the use of ``Distro Tutor Plugin`` for managing the addition and compilation of custom themes: `README of Distro <https://github.com/eduNEXT/tutor-contrib-edunext-distro?tab=readme-ov-file#themes>`_
 
 Open edX devstack
-~~~~~~~~~~~~~~~~~
+-----------------
 
-- Clone this repo in the src folder of your devstack.
-- Open a new Lms/Devstack shell.
-- Install the plugin as follows: pip install -e /path/to/your/src/folder
-- Restart lms/cms services.
+#. Clone this repo in the ``src`` folder of your devstack.
+#. Open a new ``lms/devstack`` shell.
+#. Install the plugin as follows: ``pip install -e /path/to/your/src/folder``
+#. Restart lms/cms services.
 
 Tutor
-~~~~~
-
-- Install the plugin with OPENEDX_EXTRA_PIP_REQUIREMENTS, this should be added in the config.yml. 
-- Restart lms/cms services.
-
-Usage
 -----
 
-Include a usage description for your plugin.
+#. Install the plugin adding it to ``OPENEDX_EXTRA_PIP_REQUIREMENTS`` in the ``config.yml``.
+   
+   .. code-block:: yaml
+      
+      OPENEDX_EXTRA_PIP_REQUIREMENTS:
+         - eox-theming=={{version}}
+
+#. Save the configuration with ``tutor config save``
+#. Launch the platform with ``tutor [local | dev] launch``
+
+*****
+Usage
+*****
 
 Settings
-~~~~~~~~
+--------
 
-To start using eox-theming, we must make the settings shown in the tenant settings (if we don't have one created, create it and configure it), add some available settings to the tenant:
+Next,  with ``eox-tenant`` create a new ``route`` or modify an existing one to point to a ``tenant config`` that lists your theme names in hierarchical order.  This hierarchy, which follows the priority for template lookup, uses the attributes ``name``, ``parent``, and ``grandparent`` respectively. You ``tenant config`` JSON will need a property similar to the following one:
 
 .. code-block:: json
 
-    {"THEME_OPTIONS":{"theme":{"grandparent":"test-3","name":"test-1","parent":"test-2"}}}
+    {
+        "EDNX_USE_SIGNAL": true,
+        "THEME_OPTIONS": {
+            "theme": {
+                "name":"my-theme-1",
+                "parent":"my-theme-2"
+                "grandparent":"my-theme-3",
+            }
+        }
+    }
 
+**Using Tutor**
 
-For this, you must also make sure you have eox-tenant installed in your environment,
-and to configure it we must locate the `common.py`_
-file and set the ``USE_EOX_TENANT`` variable to ``True``
+If you chose to use ``Distro Tutor Plugin``, just follow the instructions given in the `Themes section <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/master/README.md#themes>`_. Otherwise, if you are doing the process manually, follow this steps:
 
-.. _common.py: https://github.com/eduNEXT/eox-tenant/blob/master/eox_tenant/settings/common.py#L52
+#. Add the following settings to your environment file ``env/apps/openedx/settings/lms/[development | production].py``:
+
+   .. code:: python
+   
+       COMPREHENSIVE_THEME_DIRS.extend(
+           [
+               "/path-to-your-theme/in-the-lms-container/my-theme-1/edx-platform",
+               "/path-to-your-theme/in-the-lms-container/my-theme-2/edx-platform",
+               "/path-to-your-theme/in-the-lms-container/my-theme-3/edx-platform"
+           ]
+       )
+       EOX_THEMING_DEFAULT_THEME_NAME = "my-theme-1" # Or the theme you want
+   
+       ################## EOX_THEMING ##################
+       if "EOX_THEMING_DEFAULT_THEME_NAME" in locals() and EOX_THEMING_DEFAULT_THEME_NAME:
+       from lms.envs.common import _make_mako_template_dirs  # pylint: disable=import-error
+   
+   
+       ENABLE_COMPREHENSIVE_THEMING = True
+       TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
+       derive_settings("lms.envs.[devstack | production]")  # lms.envs.devstack or lms.envs.production
+
+#. Compile the before added themes according to you are using a `production environment <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/a63e585b9bc3089e00623974c8b365ea874f0a2b/README.md?plain=1#L219>`_ or a `dev environment <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/a63e585b9bc3089e00623974c8b365ea874f0a2b/README.md?plain=1#L234>`_
+
+**Using devstack**
 
 Include the follow configuration in devstack.py:
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Eox theming is a plugin for `Open edX platform <https://github.com/openedx/edx-p
 
 This plugin improves the ``edx-platform`` by enhancing its Django and Mako template management. It allows for a more flexible theming process by introducing different levels of customization, enabling templates to be accessed from various theme directories where custom themes were stored.
 
-The plugin conducts a hierarchical search for the requested template. It begins with the main theme (identified by ``name``), then moves to the second level (identified by ``parent``), and finally to the third level (identified by ``grandparent``). This hierarchical approach ensures that the plugin searches through the theme directories, prioritizing the most specific customizations over the default ones. You can find how to use the theme hierarchy in the upcoming **Usage** section.
+The plugin conducts a hierarchical search for the requested template. It begins with the main theme (identified by ``name``), then moves to the second level (identified by ``parent``), and finally to the third level (identified by ``grandparent``). This hierarchical approach ensures that the plugin searches through the theme directories, prioritizing the most specific customizations over the default ones. You can find how to use the theme hierarchy in the upcoming `Usage`_ section.
 
 If you are looking for professional development or support with multitenancy or multi-sites in the Open edX platform, you can reach out to sales@edunext.co
 
@@ -58,28 +58,23 @@ For example, if you need compatibility for Koa, you can go to the `v2.0.0 README
     EOX_THEMING_STORAGE_BACKEND = 'eox_theming.edxapp_wrapper.backends.l_storage'
     EOX_THEMING_EDXMAKO_BACKEND = 'eox_theming.edxapp_wrapper.backends.l_mako'
 
-Then you need to change the configuration in ``eox_theming/settings/common.py`` to use the previous ones.
+Then you need to change the configuration in ``eox_theming/settings/common.py`` to use the appropriated ones.
 
 🚨 If the release you are looking for is not listed, please note:
 
 - If the Open edX release is compatible with the current eox-theming version (see `Compatibility Notes <https://github.com/eduNEXT/eox-theming?tab=readme-ov-file#compatibility-notes>`_), the default configuration is sufficient.
 - If incompatible, you can refer to the README from the relevant version tag for configuration details (e.g., `v2.0.0 README <https://github.com/eduNEXT/eox-theming/blob/v2.0.0/README.md>`_).
 
+Pre-requirements
+================
+#. Ensure you have a theme or themes following the `Changing Themes guide <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/index.html>`_
+#. Ensure your environment is well-configured according to the `Settings`_ section
+
+   .. note::
+      In order to simplify this process, we encourage the use of ``Distro Tutor Plugin`` for managing the addition and compilation of custom themes: `README of Distro <https://github.com/eduNEXT/tutor-contrib-edunext-distro?tab=readme-ov-file#themes>`_
 
 Installation
 ============
-
-Pre-requirements
-----------------
-
-- Ensure you have a theme or themes following the `Changing Themes guide <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/index.html>`_ and compile them so they are accessible for the platform
-
-**NOTE**
-
-In order to simplify this process, we encourage the use of ``Distro Tutor Plugin`` for managing the addition and compilation of custom themes: `README of Distro <https://github.com/eduNEXT/tutor-contrib-edunext-distro?tab=readme-ov-file#themes>`_
-
-Using Tutor
------------
 
 #. Install the plugin adding it to ``OPENEDX_EXTRA_PIP_REQUIREMENTS`` in the ``config.yml``.
    
@@ -89,40 +84,34 @@ Using Tutor
          - eox-theming=={{version}}
 
 #. Save the configuration with ``tutor config save``
-#. Launch the platform with ``tutor [local | dev] launch``
-
-Usage
-=====
+#. Launch the platform with ``tutor local launch``
 
 Settings
---------
-
-Next,  with ``eox-tenant`` create a new ``route`` or modify an existing one to point to a ``tenant config`` that lists your theme names in hierarchical order.  This hierarchy, which follows the priority for template lookup, uses the attributes ``name``, ``parent``, and ``grandparent`` respectively. Your ``tenant config`` JSON will need a property similar to the following one:
-
-.. code-block:: json
-
-    {
-        "EDNX_USE_SIGNAL": true,
-        "THEME_OPTIONS": {
-            "theme": {
-                "name":"my-theme-1",
-                "parent":"my-theme-2",
-                "grandparent":"my-theme-3"
-            }
-        }
-    }
+========
 
 If you chose to use ``Distro Tutor Plugin``, just follow the instructions given in the `Themes section <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/master/README.md#themes>`_. Otherwise, if you are doing the process manually, follow this steps:
 
-#. Add the following settings to your environment file ``env/apps/openedx/settings/lms/[development | production].py``:
+#. Add the themes to your instance by adding your themes folder to the container shared folder ``env/build/openedx/themes``
+
+#. Compile the themes after adding them:
+    
+    .. code-block:: bash
+
+       tutor images build openedx
+       tutor local do init
+
+       # or
+
+       tutor local launch
+
+#. Add the following settings to your environment file ``env/apps/openedx/settings/lms/production.py``:
 
    .. code:: python
    
        COMPREHENSIVE_THEME_DIRS.extend(
            [
-               "/path-to-your-theme/in-the-lms-container/my-theme-1/edx-platform",
-               "/path-to-your-theme/in-the-lms-container/my-theme-2/edx-platform",
-               "/path-to-your-theme/in-the-lms-container/my-theme-3/edx-platform"
+               "/path-to-your-themes-folder/in-the-lms-container/edx-platform",
+               "/path-to-your-themes-folder/in-the-lms-container/edx-platform/sub-folder-with-more-themes",
            ]
        )
        EOX_THEMING_DEFAULT_THEME_NAME = "my-theme-1" # Or the theme you want
@@ -132,60 +121,95 @@ If you chose to use ``Distro Tutor Plugin``, just follow the instructions given 
            from lms.envs.common import _make_mako_template_dirs  # pylint: disable=import-error
            ENABLE_COMPREHENSIVE_THEMING = True
            TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
-           derive_settings("lms.envs.[devstack | production]")  # lms.envs.devstack or lms.envs.production
+           derive_settings("lms.envs.production")
 
-#. Compile the before added themes:
-  
-  - In a ``production`` environment run 
+Usage
+=====
+
+#. With ``eox-tenant`` create a new ``route`` or modify an existing one to point to a ``tenant config`` that lists your theme names in hierarchical order.  This hierarchy, which follows the priority for template lookup, uses the attributes ``name``, ``parent``, and ``grandparent`` respectively. Your ``tenant config`` JSON will need a property similar to the following one:
+
+   .. code-block:: json
+
+      {
+          "EDNX_USE_SIGNAL": true,
+          "THEME_OPTIONS": {
+              "theme": {
+                  "name":"my-theme-1",
+                  "parent":"my-theme-2",
+                  "grandparent":"my-theme-3"
+              }
+          }
+      }
+
+#. If you want to use different themes or modify the hierarchy, you just have to modify the `"THEME_OPTIONS"` property in your ``tenant config`` ensuring the theme you want to use was previously added to the platform.
+
+Use case example
+================
+
+Having the following theme folder structure:
     
-    .. code-block:: bash
+    .. code-block:: JSON
 
-      tutor images build openedx
-      tutor local do init
-      tutor local start
-
-      # or
-
-      tutor local launch
-  
-  - In a ``dev`` environment run 
+       themes-main-folder
+       ├── edx-platform
+           └── global-customizations
+               └── lms
+                   └── static
+                   └── templates
+               └── cms
+                   └── static
+                   └── templates
+           └── more-specific-customizations
+               └── org-customization-theme
+                   └── lms
+                       └── static
+                       └── templates
+                   └── cms
+                       └── static
+                       └── templates
+           └── much-more-specific-customizations
+               └── client-customization-theme
+                   └── lms
+                       └── static
+                       └── templates
+                   └── cms
+                       └── static
+                       └── templates
     
-    .. code-block:: bash
+    **NOTE**
 
-      tutor images build openedx-dev
-      tutor dev do init
-      tutor dev start
-      tutor dev exec lms bash
-      npm run compile-sass -- --theme-dir X --theme-dir Y --theme A --theme B
+    You can see there are 3 levels of customizations in the themes folder: ``global-customizations``, ``more-specific-customizations``, and ``much-more-specific-customizations``; the names are just for illustrate the hierarchy the example will follow.
 
-      # or
+#. Add the ``themes-main-folder`` to ``env/build/openedx/themes`` folder in your environment to make the themes available to the platform; this folder is shared with the container.
 
-      tutor dev launch
-      tutor dev exec lms bash
-      npm run compile-sass -- --theme-dir X --theme-dir Y --theme A --theme B
+#. Compile the themes running `tutor local launch`
 
+#. Then, ensure are properly configured the `Settings`_ required and customize these: 
 
-#. Ensure is included the following configuration in `devstack.py` in `eox-theming`:
+   .. code:: python
+   
+       COMPREHENSIVE_THEME_DIRS.extend(
+           [
+               "/openedx/themes/themes-main-folder/edx-platform",
+               "/openedx/themes/themes-main-folder/edx-platform/more-specific-customizations",
+               "/openedx/themes/themes-main-folder/edx-platform/most-specific-customizations"
+           ]
+       )
+       EOX_THEMING_DEFAULT_THEME_NAME = "client-customization-theme"
 
-   .. code-block:: python
-    
-       """
-       Production Django settings for eox_theming project.s
-       """
-       from __future__ import unicode_literals
-       def plugin_settings(settings):
-           """
-           Set of plugin settings used by the Open Edx platform.
-           More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
-           """
-           settings.STATICFILES_FINDERS = [
-               'eox_theming.theming.finders.EoxThemeFilesFinder',
-           ] + settings.STATICFILES_FINDERS
-           settings.STATICFILES_STORAGE = 'eox_theming.theming.storage.EoxDevelopmentStorage'
+#. And finally, restart the platform with the `tutor local restart` so this settings are properly added
 
-**NOTE** 
+#. Now you just have to create a `Route` with the ``"theme"`` attribute in the ``tenant config`` as follows:
 
-In ``COMPREHENSIVE_THEME_DIRS`` it must contain a list of directories where the folders of the themes to be tested are located.
+   .. code-block:: json
+
+       "theme": {
+         "name":"client-customization-theme",
+         "parent":"org-customization-theme",
+         "grandparent":"global-customizations"
+       }
+
+#. Restart again `tutor local restart` and enjoy :)
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,10 @@ Overview
 
 Eox theming is a plugin for `Open edX platform <https://github.com/openedx/edx-platform>`_, and part of the Edunext Open edX Extensions (aka EOX) that provides a series of tools to customize and launch themes.
 
+This plugin improves the ``edx-platform`` by enhancing its Django and Mako template management. It allows for a more flexible theming process by introducing different levels of customization, enabling templates to be accessed from various theme directories where custom themes were stored.
+
+The plugin conducts a hierarchical search for the requested template. It begins with the main theme (identified by ``name``), then moves to the second level (identified by ``parent``), and finally to the third level (identified by ``grandparent``). This hierarchical approach ensures that the plugin searches through the theme directories, prioritizing the most specific customizations over the default ones. You can find how to use the theme hierarchy in the upcoming **Usage** section.
+
 If you are looking for professional development or support with multitenancy or multi-sites in the Open edX platform, you can reach out to sales@edunext.co
 
 *******************
@@ -48,7 +52,7 @@ Compatibility Notes
 
 The plugin is configured for the latest release (Redwood). If you need compatibility for previous releases, go to the README of the relevant version tag and if it is necessary you can change the configuration in ``eox_theming/settings/common.py``.
 
-For example, if you need compatibility for Koa, you can go to the `v2.0.0 README <https://github.com/eduNEXT/eox-theming/blob/v2.0.0/README.rst>`_ to the ``Compatibility Notes`` section; you'll see something like this:
+For example, if you need compatibility for Koa, you can go to the `v2.0.0 README <https://github.com/eduNEXT/eox-theming/blob/v2.0.0/README.md>`_ to the ``Compatibility Notes`` section; you'll see something like this:
 
 .. code-block:: python
 
@@ -60,7 +64,7 @@ Then you need to change the configuration in ``eox_theming/settings/common.py`` 
 🚨 If the release you are looking for is not listed, please note:
 
 - If the Open edX release is compatible with the current eox-theming version (see `Compatibility Notes <https://github.com/eduNEXT/eox-theming?tab=readme-ov-file#compatibility-notes>`_), the default configuration is sufficient.
-- If incompatible, you can refer to the README from the relevant version tag for configuration details (e.g., `v2.0.0 README <https://github.com/eduNEXT/eox-theming/blob/v2.0.0/README.rst>`_).
+- If incompatible, you can refer to the README from the relevant version tag for configuration details (e.g., `v2.0.0 README <https://github.com/eduNEXT/eox-theming/blob/v2.0.0/README.rmd`_).
 
 
 ************
@@ -97,7 +101,7 @@ Usage
 Settings
 --------
 
-Next,  with ``eox-tenant`` create a new ``route`` or modify an existing one to point to a ``tenant config`` that lists your theme names in hierarchical order.  This hierarchy, which follows the priority for template lookup, uses the attributes ``name``, ``parent``, and ``grandparent`` respectively. You ``tenant config`` JSON will need a property similar to the following one:
+Next,  with ``eox-tenant`` create a new ``route`` or modify an existing one to point to a ``tenant config`` that lists your theme names in hierarchical order.  This hierarchy, which follows the priority for template lookup, uses the attributes ``name``, ``parent``, and ``grandparent`` respectively. Your ``tenant config`` JSON will need a property similar to the following one:
 
 .. code-block:: json
 
@@ -163,8 +167,9 @@ If you chose to use ``Distro Tutor Plugin``, just follow the instructions given 
 
 In ``COMPREHENSIVE_THEME_DIRS`` it must contain a list of directories where the folders of the themes to be tested are located.
 
+************
 Contributing
-------------
+************
 
 Contributions are welcome! See our `CONTRIBUTING`_
 file for more information - it also contains guidelines for how to maintain high code

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,15 @@ Compatibility Notes
 
 The plugin is configured for the latest release (Redwood). If you need compatibility for previous releases, go to the README of the relevant version tag and if it is necessary you can change the configuration in ``eox_theming/settings/common.py``.
 
+For example, if you need compatibility for Koa, you can go to the `v2.0.0 README <https://github.com/eduNEXT/eox-theming/blob/v2.0.0/README.rst>`_ to the ``Compatibility Notes`` section; you'll see something like this:
+
+.. code-block:: python
+
+    EOX_THEMING_STORAGE_BACKEND = 'eox_theming.edxapp_wrapper.backends.l_storage'
+    EOX_THEMING_EDXMAKO_BACKEND = 'eox_theming.edxapp_wrapper.backends.l_mako'
+
+Then you need to change the configuration in ``eox_theming/settings/common.py`` to use the previous ones.
+
 🚨 If the release you are looking for is not listed, please note:
 
 - If the Open edX release is compatible with the current eox-theming version (see `Compatibility Notes <https://github.com/eduNEXT/eox-theming?tab=readme-ov-file#compatibility-notes>`_), the default configuration is sufficient.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ===========
 EOX Theming
 ===========
-|Maintainance Badge| |Test Badge| |PyPI Badge|
+|Maintainance Badge| |Test Badge| |PyPI Badge| |Python Badge|
 
 .. |Maintainance Badge| image:: https://img.shields.io/badge/Status-Maintained-brightgreen
    :alt: Maintainance Status
@@ -9,6 +9,7 @@ EOX Theming
    :alt: GitHub Actions Workflow Test Status
 .. |PyPI Badge| image:: https://img.shields.io/pypi/v/eox-theming?label=PyPI
    :alt: PyPI - Version
+.. |Python Badge| image:: https://img.shields.io/pypi/pyversions/eox-theming.svg
 
 Overview
 ========
@@ -43,7 +44,7 @@ Compatibility Notes
 +------------------+--------------+
 | Quince           | >= 7.0       |
 +------------------+--------------+
-| Redwood          | >= 7.0       |
+| Redwood          | >= 7.2.0     |
 +------------------+--------------+
 
 ⚠️ From Lilac version Django 2.2 is not supported, you should use Django 3.2 and eox-tenant >=4.0.
@@ -133,7 +134,35 @@ If you chose to use ``Distro Tutor Plugin``, just follow the instructions given 
            TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
            derive_settings("lms.envs.[devstack | production]")  # lms.envs.devstack or lms.envs.production
 
-#. Compile the before added themes according to you are using a `production environment <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/a63e585b9bc3089e00623974c8b365ea874f0a2b/README.md?plain=1#L219>`_ or a `dev environment <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/a63e585b9bc3089e00623974c8b365ea874f0a2b/README.md?plain=1#L234>`_
+#. Compile the before added themes:
+  
+  - In a ``production`` environment run 
+    
+    .. code-block:: bash
+
+      tutor images build openedx
+      tutor local do init
+      tutor local start
+
+      # or
+
+      tutor local launch
+  
+  - In a ``dev`` environment run 
+    
+    .. code-block:: bash
+
+      tutor images build openedx-dev
+      tutor dev do init
+      tutor dev start
+      tutor dev exec lms bash
+      npm run compile-sass -- --theme-dir X --theme-dir Y --theme A --theme B
+
+      # or
+
+      tutor dev launch
+      tutor dev exec lms bash
+      npm run compile-sass -- --theme-dir X --theme-dir Y --theme A --theme B
 
 
 #. Ensure is included the following configuration in `devstack.py` in `eox-theming`:
@@ -166,3 +195,9 @@ file for more information - it also contains guidelines for how to maintain high
 quality, which will make your contribution more likely to be accepted.
 
 .. _CONTRIBUTING: https://github.com/eduNEXT/eox-theming/blob/master/CONTRIBUTING.rst
+
+
+License
+=======
+
+This project is licensed under the AGPL-3.0 License. See the `LICENSE <LICENSE.txt>`_ file for details.

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Then you need to change the configuration in ``eox_theming/settings/common.py`` 
 🚨 If the release you are looking for is not listed, please note:
 
 - If the Open edX release is compatible with the current eox-theming version (see `Compatibility Notes <https://github.com/eduNEXT/eox-theming?tab=readme-ov-file#compatibility-notes>`_), the default configuration is sufficient.
-- If incompatible, you can refer to the README from the relevant version tag for configuration details (e.g., `v2.0.0 README <https://github.com/eduNEXT/eox-theming/blob/v2.0.0/README.rmd`_).
+- If incompatible, you can refer to the README from the relevant version tag for configuration details (e.g., `v2.0.0 README <https://github.com/eduNEXT/eox-theming/blob/v2.0.0/README.md>`_).
 
 
 ************
@@ -74,7 +74,6 @@ Installation
 Pre-requirements
 ----------------
 
-- A compatible version of `eox-tenant <https://github.com/eduNEXT/eox-tenant>`_
 - Ensure you have a theme or themes following the `Changing Themes guide <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/index.html>`_ and compile them so they are accessible for the platform
 
 **NOTE**
@@ -141,27 +140,23 @@ If you chose to use ``Distro Tutor Plugin``, just follow the instructions given 
 #. Compile the before added themes according to you are using a `production environment <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/a63e585b9bc3089e00623974c8b365ea874f0a2b/README.md?plain=1#L219>`_ or a `dev environment <https://github.com/eduNEXT/tutor-contrib-edunext-distro/blob/a63e585b9bc3089e00623974c8b365ea874f0a2b/README.md?plain=1#L234>`_
 
 
-#. Ensure is included the follow configuration in `devstack.py` in `eox-theming`:
+#. Ensure is included the following configuration in `devstack.py` in `eox-theming`:
 
-    .. code-block:: python
-
-        """
-        Production Django settings for eox_theming project.
-        """
-
-        from __future__ import unicode_literals
-
-
-        def plugin_settings(settings):
-            """
-            Set of plugin settings used by the Open Edx platform.
-            More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
-            """
-            settings.STATICFILES_FINDERS = [
-                'eox_theming.theming.finders.EoxThemeFilesFinder',
-            ] + settings.STATICFILES_FINDERS
-
-            settings.STATICFILES_STORAGE = 'eox_theming.theming.storage.EoxDevelopmentStorage'
+   .. code-block:: python
+    
+       """
+       Production Django settings for eox_theming project.s
+       """
+       from __future__ import unicode_literals
+       def plugin_settings(settings):
+           """
+           Set of plugin settings used by the Open Edx platform.
+           More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
+           """
+           settings.STATICFILES_FINDERS = [
+               'eox_theming.theming.finders.EoxThemeFilesFinder',
+           ] + settings.STATICFILES_FINDERS
+           settings.STATICFILES_STORAGE = 'eox_theming.theming.storage.EoxDevelopmentStorage'
 
 **NOTE** 
 

--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,6 @@ This plugin improves the ``edx-platform`` by enhancing its Django and Mako templ
 
 The plugin conducts a hierarchical search for the requested template. It begins with the main theme (identified by ``name``), then moves to the second level (identified by ``parent``), and finally to the third level (identified by ``grandparent``). This hierarchical approach ensures that the plugin searches through the theme directories, prioritizing the most specific customizations over the default ones. You can find how to use the theme hierarchy in the upcoming `Usage`_ section.
 
-If you are looking for professional development or support with multitenancy or multi-sites in the Open edX platform, you can reach out to sales@edunext.co
-
 Compatibility Notes
 ===================
 
@@ -148,37 +146,37 @@ Use case example
 
 Having the following theme folder structure:
     
-    .. code-block:: txt
+.. code-block:: txt
 
-        themes-main-folder
-        ├── edx-platform
-            └── global-customizations
+    themes-main-folder
+    ├── edx-platform
+        └── global-customizations
+            └── lms
+                └── static
+                └── templates
+            └── cms
+                └── static
+                └── templates
+        └── more-specific-customizations
+            └── org-customization-theme
                 └── lms
                     └── static
                     └── templates
                 └── cms
                     └── static
                     └── templates
-            └── more-specific-customizations
-                └── org-customization-theme
-                    └── lms
-                        └── static
-                        └── templates
-                    └── cms
-                        └── static
-                        └── templates
-            └── much-more-specific-customizations
-                └── client-customization-theme
-                    └── lms
-                        └── static
-                        └── templates
-                    └── cms
-                        └── static
-                        └── templates
+        └── much-more-specific-customizations
+            └── client-customization-theme
+                └── lms
+                    └── static
+                    └── templates
+                └── cms
+                    └── static
+                    └── templates
 
-    **NOTE**
+**NOTE**
 
-    You can see there are 3 levels of customization in the themes folder: ``global-customizations``, ``more-specific-customizations``, and ``much-more-specific-customizations``; the names are just to illustrate the hierarchy that the example will follow.
+You can see there are 3 levels of customization in the themes folder: ``global-customizations``, ``more-specific-customizations``, and ``much-more-specific-customizations``; the names are just to illustrate the hierarchy that the example will follow.
 
 #. Add the ``themes-main-folder`` to ``env/build/openedx/themes`` folder in your environment to make the themes available to the platform; this folder is shared with the container.
 
@@ -199,7 +197,7 @@ Having the following theme folder structure:
 
 #. And finally, restart the platform with the ``tutor local restart`` so this settings are properly added
 
-#. Now you just have to create a `Route` with the ``"theme"`` attribute in the ``tenant config`` as follows:
+#. Now you just have to create a ``Route`` with the ``"theme"`` attribute in the ``tenant config`` to point to your themes in the hierarchy you choose:
 
    .. code-block:: json
 

--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,8 @@ EOX Theming
 .. |PyPI Badge| image:: https://img.shields.io/pypi/v/eox-theming?label=PyPI
    :alt: PyPI - Version
 
-********
 Overview
-********
+========
 
 Eox theming is a plugin for `Open edX platform <https://github.com/openedx/edx-platform>`_, and part of the Edunext Open edX Extensions (aka EOX) that provides a series of tools to customize and launch themes.
 
@@ -22,9 +21,8 @@ The plugin conducts a hierarchical search for the requested template. It begins 
 
 If you are looking for professional development or support with multitenancy or multi-sites in the Open edX platform, you can reach out to sales@edunext.co
 
-*******************
 Compatibility Notes
-*******************
+===================
 
 +------------------+--------------+
 | Open edX Release | Version      |
@@ -67,9 +65,8 @@ Then you need to change the configuration in ``eox_theming/settings/common.py`` 
 - If incompatible, you can refer to the README from the relevant version tag for configuration details (e.g., `v2.0.0 README <https://github.com/eduNEXT/eox-theming/blob/v2.0.0/README.md>`_).
 
 
-************
 Installation
-************
+============
 
 Pre-requirements
 ----------------
@@ -93,9 +90,8 @@ Using Tutor
 #. Save the configuration with ``tutor config save``
 #. Launch the platform with ``tutor [local | dev] launch``
 
-*****
 Usage
-*****
+=====
 
 Settings
 --------
@@ -162,9 +158,8 @@ If you chose to use ``Distro Tutor Plugin``, just follow the instructions given 
 
 In ``COMPREHENSIVE_THEME_DIRS`` it must contain a list of directories where the folders of the themes to be tested are located.
 
-************
 Contributing
-************
+============
 
 Contributions are welcome! See our `CONTRIBUTING`_
 file for more information - it also contains guidelines for how to maintain high code

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ EOX Theming
 Overview
 ********
 
-Eox theming is a plugin for `Open edX <https://github.com/openedx/edx-platform>`_, and part of the Edunext Open Extensiones (aka EOX) that provides a stable place from where to create and launch themes to the Open edX platform.
+Eox theming is a plugin for `Open edX platform <https://github.com/openedx/edx-platform>`_, and part of the Edunext Open edX Extensions (aka EOX) that provides a series of tools to customize and launch themes.
 
 If you are looking for professional development or support with multitenancy or multi-sites in the Open edX platform, you can reach out to sales@edunext.co
 

--- a/README.rst
+++ b/README.rst
@@ -95,14 +95,14 @@ If you chose to use ``Distro Tutor Plugin``, just follow the instructions given 
 
 #. Compile the themes after adding them:
     
-    .. code-block:: bash
+   .. code-block:: bash
 
-       tutor images build openedx
-       tutor local do init
+      tutor images build openedx
+      tutor local do init
 
        # or
 
-       tutor local launch
+      tutor local launch
 
 #. Add the following settings to your environment file ``env/apps/openedx/settings/lms/production.py``:
 
@@ -148,37 +148,37 @@ Use case example
 
 Having the following theme folder structure:
     
-    .. code-block:: JSON
+    .. code-block:: txt
 
-       themes-main-folder
-       ├── edx-platform
-           └── global-customizations
-               └── lms
-                   └── static
-                   └── templates
-               └── cms
-                   └── static
-                   └── templates
-           └── more-specific-customizations
-               └── org-customization-theme
-                   └── lms
-                       └── static
-                       └── templates
-                   └── cms
-                       └── static
-                       └── templates
-           └── much-more-specific-customizations
-               └── client-customization-theme
-                   └── lms
-                       └── static
-                       └── templates
-                   └── cms
-                       └── static
-                       └── templates
-    
+        themes-main-folder
+        ├── edx-platform
+            └── global-customizations
+                └── lms
+                    └── static
+                    └── templates
+                └── cms
+                    └── static
+                    └── templates
+            └── more-specific-customizations
+                └── org-customization-theme
+                    └── lms
+                        └── static
+                        └── templates
+                    └── cms
+                        └── static
+                        └── templates
+            └── much-more-specific-customizations
+                └── client-customization-theme
+                    └── lms
+                        └── static
+                        └── templates
+                    └── cms
+                        └── static
+                        └── templates
+
     **NOTE**
 
-    You can see there are 3 levels of customizations in the themes folder: ``global-customizations``, ``more-specific-customizations``, and ``much-more-specific-customizations``; the names are just for illustrate the hierarchy the example will follow.
+    You can see there are 3 levels of customization in the themes folder: ``global-customizations``, ``more-specific-customizations``, and ``much-more-specific-customizations``; the names are just to illustrate the hierarchy that the example will follow.
 
 #. Add the ``themes-main-folder`` to ``env/build/openedx/themes`` folder in your environment to make the themes available to the platform; this folder is shared with the container.
 
@@ -197,7 +197,7 @@ Having the following theme folder structure:
        )
        EOX_THEMING_DEFAULT_THEME_NAME = "client-customization-theme"
 
-#. And finally, restart the platform with the `tutor local restart` so this settings are properly added
+#. And finally, restart the platform with the ``tutor local restart`` so this settings are properly added
 
 #. Now you just have to create a `Route` with the ``"theme"`` attribute in the ``tenant config`` as follows:
 
@@ -209,7 +209,7 @@ Having the following theme folder structure:
          "grandparent":"global-customizations"
        }
 
-#. Restart again `tutor local restart` and enjoy :)
+#. Restart again with ``tutor local restart`` and enjoy :)
 
 Contributing
 ============

--- a/eox_theming/__init__.py
+++ b/eox_theming/__init__.py
@@ -4,4 +4,4 @@ Init module for eox_theming.
 
 from __future__ import unicode_literals
 
-__version__ = '7.1.0'
+__version__ = '7.1.1'

--- a/eox_theming/__init__.py
+++ b/eox_theming/__init__.py
@@ -4,4 +4,4 @@ Init module for eox_theming.
 
 from __future__ import unicode_literals
 
-__version__ = '7.1.1'
+__version__ = '7.2.0'

--- a/eox_theming/edxapp_wrapper/config_sources.py
+++ b/eox_theming/edxapp_wrapper/config_sources.py
@@ -21,13 +21,13 @@ def from_site_config(*args):
     """
     This source is compatible with the site_configurations from Open edX platform.
     """
+    value = None
     options_dict = configuration_helpers.get_value("THEME_OPTIONS", {})
     if args:
         try:
             value = reduce(operator.getitem, args, options_dict)
         except (AttributeError, KeyError):
             LOG.debug("Found nothing when reading the theme options for %s", ".".join(args))
-            value = None
     return value
 
 
@@ -81,6 +81,7 @@ def from_django_settings(*args):
     """
     Takes a THEME_OPTIONS dictionary in the settings module as the source.
     """
+    value = None
     options_dict = getattr(settings, "THEME_OPTIONS", {})
 
     if args:
@@ -88,5 +89,4 @@ def from_django_settings(*args):
             value = reduce(operator.getitem, args, options_dict)
         except (AttributeError, KeyError):
             LOG.debug("Found nothing when reading the theme options for %s on django settings", ".".join(args))
-            value = None
     return value

--- a/eox_theming/settings/common.py
+++ b/eox_theming/settings/common.py
@@ -42,7 +42,7 @@ DATABASES = {
 def plugin_settings(settings):
     """
     Set of plugin settings used by the Open Edx platform.
-    More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
+    More info: https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
     settings.STATICFILES_FINDERS = [
         'eox_theming.theming.finders.EoxThemeFilesFinder',

--- a/eox_theming/settings/devstack.py
+++ b/eox_theming/settings/devstack.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 def plugin_settings(settings):
     """
     Set of plugin settings used by the Open Edx platform.
-    More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
+    More info: https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
     settings.STATICFILES_FINDERS = [
         'eox_theming.theming.finders.EoxThemeFilesFinder',

--- a/eox_theming/settings/production.py
+++ b/eox_theming/settings/production.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 def plugin_settings(settings):
     """
     Set of plugin settings used by the Open Edx platform.
-    More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
+    More info: https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
     settings.EOX_THEMING_DEFAULT_THEME_NAME = getattr(settings, 'ENV_TOKENS', {}).get(
         'EOX_THEMING_DEFAULT_THEME_NAME',

--- a/eox_theming/theming/template_loaders.py
+++ b/eox_theming/theming/template_loaders.py
@@ -93,6 +93,6 @@ class EoxThemeFilesystemLoader(ThemeFilesystemLoader):
         https://github.com/eduNEXT/edunext-platform/blob/master/openedx/core/djangoapps/theming/template_loaders.py#L39
         instead of using the cached values of self.dirs on runtime.
         """
-        theme_dirs = ThemeFilesystemLoader.get_theme_template_sources()
+        theme_dirs = self.get_theme_template_sources()
 
         return theme_dirs if theme_dirs else super().get_dirs()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,19 +8,20 @@ asgiref==3.8.1
     # via django
 backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
     #   django
-django==4.2.13
+django==4.2.14
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
     #   -r requirements/base.in
-eox-tenant==11.2.0
+eox-tenant==11.7.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
 six==1.16.0
     # via -r requirements/base.in
-sqlparse==0.5.0
+sqlparse==0.5.1
     # via django
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via asgiref

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,12 +8,11 @@ asgiref==3.8.1
     # via django
 backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
-    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   django
 django==4.2.14
     # via
-    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/common_constraints.txt
-    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
 eox-tenant==11.7.0
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,9 +15,7 @@ django==4.2.14
     #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
 eox-tenant==11.7.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+    # via -r requirements/base.in
 six==1.16.0
     # via -r requirements/base.in
 sqlparse==0.5.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,8 +8,13 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# Constraints for Open edX Redwood release
--c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
+# Must be the same used in the platform https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
+Django<5.0
+click==8.1.6
+backports.zoneinfo;python_version<"3.9"
+path<16.12.0
+pycodestyle<2.9.0
+pylint<2.16.0
 
 # Version used in Redwood version of eox-tenant
 eox-tenant < 12.0.0 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,8 +8,10 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# Must be the same used in the platform https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
-Django<5.0
+# Common constraints for Open edX repos
+-c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
+
+# Keep same platform version
 click==8.1.6
 backports.zoneinfo;python_version<"3.9"
 path<16.12.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,9 +11,5 @@
 # Common constraints for Open edX repos
 -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-# Keep same platform version
-click==8.1.6
-backports.zoneinfo;python_version<"3.9"
-path<16.12.0
-pycodestyle<2.9.0
-pylint<2.16.0
+# backports.zoneinfo is only needed for Python < 3.9
+backports.zoneinfo; python_version<'3.9'

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,6 +17,3 @@ backports.zoneinfo;python_version<"3.9"
 path<16.12.0
 pycodestyle<2.9.0
 pylint<2.16.0
-
-# Version used in Redwood version of eox-tenant
-eox-tenant < 12.0.0 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,14 +8,8 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# Keep same platform version
-Django<5.0
-pylint<2.16.0
-pycodestyle<2.9.0
-click<9.0
+# Constraints for Open edX Redwood release
+-c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
 
-# Version used in Palm version of eox-tenant
-eox-tenant>= 10.0.0
-
-# backports.zoneinfo is only needed for Python < 3.9
-backports.zoneinfo; python_version<'3.9'
+# Version used in Redwood version of eox-tenant
+eox-tenant < 12.0.0 

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,11 +8,11 @@ build==1.2.1
     # via pip-tools
 click==8.1.6
     # via
-    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   pip-tools
 importlib-metadata==6.11.0
     # via
-    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   build
 packaging==24.1
     # via build

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,13 +6,15 @@
 #
 build==1.2.1
     # via pip-tools
-click==8.1.7
+click==8.1.6
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
     #   pip-tools
-importlib-metadata==7.1.0
-    # via build
-packaging==24.0
+importlib-metadata==6.11.0
+    # via
+    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/common_constraints.txt
+    #   build
+packaging==24.1
     # via build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,10 +6,8 @@
 #
 build==1.2.1
     # via pip-tools
-click==8.1.6
-    # via
-    #   -c requirements/constraints.txt
-    #   pip-tools
+click==8.1.7
+    # via pip-tools
 importlib-metadata==6.11.0
     # via
     #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ astroid==2.13.5
     #   pylint
 backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
-    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django
 coverage==7.6.0
@@ -22,8 +22,7 @@ coverage==7.6.0
 dill==0.3.8
     # via pylint
     # via
-    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/common_constraints.txt
-    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.in
 eox-tenant==11.7.0
@@ -44,7 +43,7 @@ mock==5.1.0
     # via -r requirements/test.in
 path==16.11.0
     # via
-    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   path-py
 path-py==12.5.0
     # via -r requirements/test.in
@@ -52,11 +51,11 @@ platformdirs==4.2.2
     # via pylint
 pycodestyle==2.8.0
     # via
-    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
 pylint==2.15.10
     # via
-    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
 pyyaml==6.0.1
     # via -r requirements/test.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.13.5
+astroid==3.2.4
     # via
     #   -r requirements/test.in
     #   pylint
@@ -26,13 +26,9 @@ dill==0.3.8
     #   -r requirements/base.txt
     #   -r requirements/test.in
 eox-tenant==11.7.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+    # via -r requirements/base.txt
 isort==5.13.2
     # via pylint
-lazy-object-proxy==1.10.0
-    # via astroid
 mako==1.3.5
     # via -r requirements/test.in
 markupsafe==2.1.5
@@ -41,22 +37,16 @@ mccabe==0.7.0
     # via pylint
 mock==5.1.0
     # via -r requirements/test.in
-path==16.11.0
-    # via
-    #   -c requirements/constraints.txt
-    #   path-py
+path==17.0.0
+    # via path-py
 path-py==12.5.0
     # via -r requirements/test.in
 platformdirs==4.2.2
     # via pylint
-pycodestyle==2.8.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
-pylint==2.15.10
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
+pycodestyle==2.12.0
+    # via -r requirements/test.in
+pylint==3.2.6
+    # via -r requirements/test.in
 pyyaml==6.0.1
     # via -r requirements/test.in
 six==1.16.0
@@ -77,5 +67,3 @@ typing-extensions==4.12.2
     #   asgiref
     #   astroid
     #   pylint
-wrapt==1.16.0
-    # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,18 +14,19 @@ astroid==2.13.5
     #   pylint
 backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
     #   -r requirements/base.txt
     #   django
-coverage==7.5.3
+coverage==7.6.0
     # via -r requirements/test.in
 dill==0.3.8
     # via pylint
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.in
-eox-tenant==11.2.0
+eox-tenant==11.7.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -41,35 +42,37 @@ mccabe==0.7.0
     # via pylint
 mock==5.1.0
     # via -r requirements/test.in
-path==16.14.0
-    # via path-py
+path==16.11.0
+    # via
+    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
+    #   path-py
 path-py==12.5.0
     # via -r requirements/test.in
 platformdirs==4.2.2
     # via pylint
 pycodestyle==2.8.0
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
     #   -r requirements/test.in
 pylint==2.15.10
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-platform/open-release/redwood.master/requirements/constraints.txt
     #   -r requirements/test.in
 pyyaml==6.0.1
     # via -r requirements/test.in
 six==1.16.0
     # via -r requirements/base.txt
-sqlparse==0.5.0
+sqlparse==0.5.1
     # via
     #   -r requirements/base.txt
     #   django
-testfixtures==8.2.0
+testfixtures==8.3.0
     # via -r requirements/test.in
 tomli==2.0.1
     # via pylint
-tomlkit==0.12.5
+tomlkit==0.13.0
     # via pylint
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via
     #   -r requirements/base.txt
     #   asgiref

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==5.3.3
+cachetools==5.4.0
     # via tox
 chardet==5.2.0
     # via tox
@@ -12,11 +12,11 @@ colorama==0.4.6
     # via tox
 distlib==0.3.8
     # via virtualenv
-filelock==3.14.0
+filelock==3.15.4
     # via
     #   tox
     #   virtualenv
-packaging==24.0
+packaging==24.1
     # via
     #   pyproject-api
     #   tox
@@ -26,13 +26,13 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via tox
-pyproject-api==1.6.1
+pyproject-api==1.7.1
     # via tox
 tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==4.15.1
+tox==4.16.0
     # via -r requirements/tox.in
-virtualenv==20.26.2
+virtualenv==20.26.3
     # via tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 7.1.0
+current_version = 7.1.1
 commit = False
 tag = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 7.1.1
+current_version = 7.2.0
 commit = False
 tag = False
 


### PR DESCRIPTION
## Description

This PR aims to upgrade the plugin and workflow requirements, update the README and make it clearer, and fix a bug with the `footer_override` rendering [Issue 9](https://github.com/eduNEXT/eox-release/issues/9). 

## Testing instructions

1. Create a redwood environment and install distro `pip install git+https://github.com/eduNEXT/tutor-contrib-edunext-distro`
2. Install the MFE tutor plugin and enable it
3. Add the following settings in the `config.yml`
``` yml
DISTRO_EOX_THEMING_DPKG:
  domain: github.com
  index: git
  name: eox-theming
  path: eduNEXT
  private: false
  protocol: https
  repo: eox-theming
  variables:
    development:
      EOX_THEMING_CONFIG_SOURCES:
      - from_eox_tenant_microsite_v2
      - from_django_settings
    production:
      EOX_THEMING_CONFIG_SOURCES:
      - from_eox_tenant_microsite_v2
      - from_django_settings
  version: bc/redwood-compatibility
OPENEDX_EXTRA_PIP_REQUIREMENTS:
- eox-tenant
DISTRO_THEMES:
- domain: github.com
  name: ednx-test-themes
  path: eduNEXT
  protocol: ssh
  repo: ednx-test-themes
  version: bc/test-footer
DISTRO_THEMES_NAME:
- test-1
- test-2
- test-3
DISTRO_THEMES_ROOT: /openedx/themes
DISTRO_THEME_DIRS:
- /openedx/themes/ednx-test-themes/edx-platform
```
4. Clone the test themes folder with `tutor distro enable-themes`
5. Add the testing themes running and init the environment running `tutor dev launch`
6. Create a new tenant and add this info to the tenant configs:
``` json
{
    "EDNX_USE_SIGNAL": true,
    "ENABLE_AUTHN_MICROFRONTEND": false,
    "ENABLE_ACCOUNT_MICROFRONTEND": false,
    "THEME_OPTIONS": {
        "scripts": {
            "/login": [
                {
                    "content": "alert('This is a test for the inline script');",
                    "type": "inline"
                }
            ]
        },
        "theme": {
            "grandparent": "test-3",
            "name": "test-1",
            "parent": "test-2"
        }
    },
    "course_org_filter": [
        "OpenedX"
    ],
    "footer_override": "<div style=\"width: 100%;\"><div style=\"position: relative; padding-bottom: 41.67%; padding-top: 0; height: 0;\"><iframe title=\"Footer X\" frameborder=\"0\" width=\"1200\" height=\"500\" style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%;\" src=\"https://view.genially.com/66464d3334225f0015c0dc0e\" type=\"text/html\" allowscriptaccess=\"always\" allowfullscreen=\"true\" scrolling=\"yes\" allownetworking=\"all\"></iframe> </div> </div>",
    "header_langselector": true,
    "header_links": [
        {
            "target": "_self",
            "txt": "Courses",
            "url": "/courses"
        },
        {
            "class": "mx-2",
            "target": "_self"
        }
    ],
    "released_languages": "en,vi,es-419"
}
```
7. Go to your admin panel and create a waffle flag `learner_home_mfe.enabled` with the property `Everyone` in false to disable the Authn MFE
8. The test cases from [this file](https://docs.google.com/document/d/18urdJPitAu1lUBvYdQcGXm4WRDbKD2eDf4TTGgrlzZU/edit)

To test the solved bug:
1. Add the demo course `tutor dev do importdemocourse`
2. Enable the Wiki going to http://apps.local.edly.io:2001/course-authoring/course/course-v1:OpenedX+DemoX+DemoCourse/pages-and-resources/wiki/settings
3. Then go to the course Wiki http://local.edly.io:8000/wiki/OpenedX.DemoX.DemoCourse/
4. You should see the footer overridden with the code of 'footer_override' from the tenant settings

## JIRA ISSUES
- [DS-1067](https://edunext.atlassian.net/browse/DS-1067)
- [DS-1098](https://edunext.atlassian.net/browse/DS-1098)
- [DS-1012](https://edunext.atlassian.net/browse/DS-1012)

[DS-1067]: https://edunext.atlassian.net/browse/DS-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ