### PR TITLE
build: use openedx commitlint workflow `AP-1595`

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,9 +3,4 @@ on: [pull_request]
 
 jobs:
   commitlint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
+    uses: openedx/.github/.github/workflows/commitlint.yml@master


### PR DESCRIPTION
### Description
This PR updates the `commitlint.yml` workflow to use Open edX's reusable workflow. This change is mainly to align with the platform workflows.

### Testing Instructions
See the **Lint Commit Messages** job

### Additional Information
- https://github.com/eduNEXT/eox-theming/pull/72#issuecomment-2456698858

### Jira Issues
[AP-1595](https://edunext.atlassian.net/browse/AP-1595)

[AP-1595]: https://edunext.atlassian.net/browse/AP-1595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ